### PR TITLE
validateLink: expand entities before trimming and lowercasing

### DIFF
--- a/lib/parser_inline.js
+++ b/lib/parser_inline.js
@@ -30,10 +30,10 @@ var _rules = [
 var BAD_PROTOCOLS = [ 'vbscript', 'javascript', 'file' ];
 
 function validateLink(url) {
-  var str = url.trim().toLowerCase();
-
   // Care about digital entities "javascript&#x3A;alert(1)"
-  str = replaceEntities(str);
+  var str = replaceEntities(url);
+
+  str = str.trim().toLowerCase();
 
   if (str.indexOf(':') >= 0 && BAD_PROTOCOLS.indexOf(str.split(':')[0]) >= 0) {
     return false;

--- a/test/fixtures/markdown-it/xss.txt
+++ b/test/fixtures/markdown-it/xss.txt
@@ -29,8 +29,15 @@ Should not allow some protocols in links and images
 
 .
 [xss link](&#34;&#62;&#60;script&#62;alert&#40;&#34;xss&#34;&#41;&#60;/script&#62;)
+
+[xss link](&#74;avascript:alert(1))
+
+[xss link](&#x26;#74;avascript:alert(1))
+
 .
 <p><a href="%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E">xss link</a></p>
+<p>[xss link](Javascript:alert(1))</p>
+<p>[xss link](&amp;#74;avascript:alert(1))</p>
 .
 
 .


### PR DESCRIPTION
Logically, the HTML entities should be expanded before the calls to `trim()` and `toLowerCase()`, otherwise there's a possibility that a malicious input can slip past the validation, because the entities can expand to `\n`, `\t`, space and/or capital letters, e.g. `&#0x0a;`, `&#x26;#74;avascript:alert(1)` etc. Now, it doesn't seem to result in a vulnerability (`escapeHTML()` takes care of `&`s), but I wouldn't take such a risk.