### PR TITLE
Remove unused assignment

### DIFF
--- a/lib/rules_block/reference.js
+++ b/lib/rules_block/reference.js
@@ -24,7 +24,7 @@ module.exports = function reference(state, startLine, _endLine, silent) {
       title,
       lines = 0,
       pos = state.bMarks[startLine] + state.tShift[startLine],
-      max = state.eMarks[startLine],
+      max,
       nextLine = startLine + 1;
 
   if (state.src.charCodeAt(pos) !== 0x5B/* [ */) { return false; }


### PR DESCRIPTION
A value assigned to the `max` variable is not used: [reference.js#L27](https://github.com/markdown-it/markdown-it/blob/4d6ec19d091477c5cdc9fbcca29dcef8a979d3c3/lib/rules_block/reference.js#L27). 30 lines below it is reassigned: [reference.js#L56](https://github.com/markdown-it/markdown-it/blob/4d6ec19d091477c5cdc9fbcca29dcef8a979d3c3/lib/rules_block/reference.js#L56).