### PR TITLE
Small fix in ruler documentation example

### DIFF
--- a/lib/ruler.js
+++ b/lib/ruler.js
@@ -225,7 +225,7 @@ Ruler.prototype.after = function (afterName, ruleName, fn, options) {
  * ```javascript
  * var md = require('markdown-it')();
  *
- * md.core.ruler.push('emphasis', 'my_rule', function replace(state) {
+ * md.core.ruler.push('my_rule', function replace(state) {
  *   //...
  * });
  * ```


### PR DESCRIPTION
Was looking at the docs, found a minor error in the example for `ruler.push`.