### PR TITLE
Don't split cells on pipe characters inside backticks.

### DIFF
--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -16,12 +16,17 @@ function escapedSplit(str) {
       max = str.length,
       ch,
       escapes = 0,
-      lastPos = 0;
+      lastPos = 0,
+      backTicked = false,
+      lastBackTick = 0;
 
   ch  = str.charCodeAt(pos);
 
   while (pos < max) {
-    if (ch === 0x7c/* | */ && (escapes % 2 === 0)) {
+    if (ch === 0x60/* ` */ && (escapes % 2 === 0)) {
+      backTicked = !backTicked;
+      lastBackTick = pos;
+    } else if (ch === 0x7c/* | */ && (escapes % 2 === 0) && !backTicked) {
       result.push(str.substring(lastPos, pos));
       lastPos = pos + 1;
     } else if (ch === 0x5c/* \ */) {
@@ -30,7 +35,16 @@ function escapedSplit(str) {
       escapes = 0;
     }
 
-    ch  = str.charCodeAt(++pos);
+    pos++;
+
+    // If there was an un-closed backtick, go back to just after
+    // the last backtick, but as if it was a normal character
+    if (pos === max && backTicked) {
+      backTicked = false;
+      pos = lastBackTick + 1;
+    }
+
+    ch = str.charCodeAt(pos);
   }
 
   result.push(str.substring(lastPos));

--- a/test/fixtures/markdown-it/tables.txt
+++ b/test/fixtures/markdown-it/tables.txt
@@ -327,6 +327,87 @@ Delimiter escaping:
 </table>
 .
 
+Pipes inside backticks don't split cells:
+.
+| Heading 1 | Heading 2
+| --------- | ---------
+| Cell 1 | Cell 2
+| `Cell|3` | Cell 4
+.
+<table>
+<thead>
+<tr>
+<th>Heading 1</th>
+<th>Heading 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td><code>Cell|3</code></td>
+<td>Cell 4</td>
+</tr>
+</tbody>
+</table>
+.
+
+Unclosed backticks don't count
+.
+| Heading 1 | Heading 2
+| --------- | ---------
+| Cell 1 | Cell 2
+| `Cell 3| Cell 4
+.
+<table>
+<thead>
+<tr>
+<th>Heading 1</th>
+<th>Heading 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td>`Cell 3</td>
+<td>Cell 4</td>
+</tr>
+</tbody>
+</table>
+.
+
+Another complicated backticks case
+.
+| Heading 1 | Heading 2
+| --------- | ---------
+| Cell 1 | Cell 2
+| \\\`|\\\`
+.
+<table>
+<thead>
+<tr>
+<th>Heading 1</th>
+<th>Heading 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td>\`</td>
+<td>\`</td>
+</tr>
+</tbody>
+</table>
+.
+
 
 Add/remove columns to match the first row:
 .


### PR DESCRIPTION
This is for #86. As I said over there I'm not _entirely_ sure whether this should be considered the correct behaviour, but if it is, then this addresses that.