### PR TITLE
Added smart arrow support to typographer

### DIFF
--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -1,4 +1,4 @@
-// Simple typographyc replacements
+// Simple typographic replacements
 //
 // '' → ‘’
 // "" → “”. Set '«»' for Russian, '„“' for German, empty to disable
@@ -10,6 +10,8 @@
 // ... → … (also ?.... → ?.., !.... → !..)
 // ???????? → ???, !!!!! → !!!, `,,` → `,`
 // -- → &ndash;, --- → &mdash;
+// --> → →; <-- → ←; <--> → ↔
+// ==> → ⇒; <== → ⇐; <==> → ⇔
 //
 'use strict';
 
@@ -17,7 +19,7 @@
 // - fractionals 1/2, 1/4, 3/4 -> ½, ¼, ¾
 // - miltiplication 2 x 4 -> 2 × 4
 
-var RARE_RE = /\+-|\.\.|\?\?\?\?|!!!!|,,|--/;
+var RARE_RE = /\+-|\.\.|\?\?\?\?|!!!!|,,|--|==/;
 
 // Workaround for phantomjs - need regex without /g flag,
 // or root check will fail every second time
@@ -59,6 +61,24 @@ function replace_rare(inlineTokens) {
                     // but ?..... & !..... -> ?.. & !..
                     .replace(/\.{2,}/g, '…').replace(/([?!])…/g, '$1..')
                     .replace(/([?!]){4,}/g, '$1$1$1').replace(/,{2,}/g, ',')
+                    // <-->
+                    .replace(/(^|\s)<-->(\s|$)/mg, '$1\u2194$2')
+                    .replace(/(^|[^<\s])<-->([^>\s]|$)/mg, '$1\u2194$2')
+                    // -->
+                    .replace(/(^|\s)-->(\s|$)/mg, '$1\u2192$2')
+                    .replace(/(^|[^-\s])-->([^>\s]|$)/mg, '$1\u2192$2')
+                    // -->
+                    .replace(/(^|\s)<--(\s|$)/mg, '$1\u2190$2')
+                    .replace(/(^|[^<\s])<--([^-\s]|$)/mg, '$1\u2190$2')
+                    // <==>
+                    .replace(/(^|\s)<==>(\s|$)/mg, '$1\u21d4$2')
+                    .replace(/(^|[^<\s])<==>([^>\s]|$)/mg, '$1\u21d4$2')
+                    // ==>
+                    .replace(/(^|\s)==>(\s|$)/mg, '$1\u21d2$2')
+                    .replace(/(^|[^=\s])==>([^>\s]|$)/mg, '$1\u21d2$2')
+                    // -->
+                    .replace(/(^|\s)<==(\s|$)/mg, '$1\u21d0$2')
+                    .replace(/(^|[^<\s])<==([^=\s]|$)/mg, '$1\u21d0$2')
                     // em-dash
                     .replace(/(^|[^-])---([^-]|$)/mg, '$1\u2014$2')
                     // en-dash

--- a/test/fixtures/markdown-it/typographer.txt
+++ b/test/fixtures/markdown-it/typographer.txt
@@ -79,3 +79,26 @@ markdownit--awesome
 <p>–markdownit – super–</p>
 <p>markdownit–awesome</p>
 .
+
+
+arrows
+.
+--> <-- <--> ==> <== <==>
+
+==>markdownit <==> super<==
+
+markdownit==>awesome<==>yay<==arrows
+
+abc ----> <---- -->> <<-- ===> <<== <<==>>
+
+-->markdownit <--> super<--
+
+markdownit-->awesome<-->yay<--arrows
+.
+<p>→ ← ↔ ⇒ ⇐ ⇔</p>
+<p>⇒markdownit ⇔ super⇐</p>
+<p>markdownit⇒awesome⇔yay⇐arrows</p>
+<p>abc ----&gt; &lt;---- --&gt;&gt; &lt;&lt;-- ===&gt; &lt;&lt;== &lt;&lt;==&gt;&gt;</p>
+<p>→markdownit ↔ super←</p>
+<p>markdownit→awesome↔yay←arrows</p>
+.


### PR DESCRIPTION
Here are the additions:

```
--> →
<-- ←
<--> ↔
==> ⇒
<== ⇐
<==> ⇔
```

I [created a plugin](https://github.com/adam-p/markdown-it-typographer-plus) to do this, but then I figured you might like the option of adding it upstream.
