### PR TITLE
Enable configuration of linkify target in config

### DIFF
--- a/lib/rules_core/linkify.js
+++ b/lib/rules_core/linkify.js
@@ -18,7 +18,7 @@ function isLinkClose(str) {
 
 module.exports = function linkify(state) {
   var i, j, l, tokens, token, currentToken, nodes, ln, text, pos, lastPos,
-      level, htmlLinkLevel, url, fullUrl, urlText,
+      level, htmlLinkLevel, url, fullUrl, urlText, linkAttrs,
       blockTokens = state.tokens,
       links;
 
@@ -98,8 +98,13 @@ module.exports = function linkify(state) {
             nodes.push(token);
           }
 
+          linkAttrs = [ [ 'href', fullUrl ] ];
+          if (state.md.options.linkify.target) {
+            linkAttrs.push([ 'target', state.md.options.linkify.target ]);
+          }
+
           token         = new state.Token('link_open', 'a', 1);
-          token.attrs   = [ [ 'href', fullUrl ] ];
+          token.attrs   = linkAttrs;
           token.level   = level++;
           token.markup  = 'linkify';
           token.info    = 'auto';


### PR DESCRIPTION
I wanted linkify links to open in a new window, but couldn't see a way of enabling this.

- Passing the config `{ linkify: true }` will work as it does currently
- Passing the config `{ linkify: { target: '_blank' } }` will cause all linkify links to open in a new window