### PR TITLE
sample.md: fix spelling of "subscript" and "superscript"

### DIFF
--- a/support/demo_template/sample.md
+++ b/support/demo_template/sample.md
@@ -172,7 +172,7 @@ The killer feature of `markdown-it` is very effective support of
 see [how to change output](https://github.com/markdown-it/markdown-it-emoji#change-output) with twemoji.
 
 
-### [Subscipt](https://github.com/markdown-it/markdown-it-sub) / [Superscirpt](https://github.com/markdown-it/markdown-it-sup)
+### [Subscript](https://github.com/markdown-it/markdown-it-sub) / [Superscript](https://github.com/markdown-it/markdown-it-sup)
 
 - 19^th^
 - H~2~O


### PR DESCRIPTION
I noticed these typos in the sample document. I don't work with JS, so I don't know how to run the tests. Are there any tests that interact with this sample?