### PR TITLE
default empty sandbox

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -488,6 +488,7 @@ MarkdownIt.prototype.use = function (plugin /*, params, ... */) {
  * and then pass updated object to renderer.
  **/
 MarkdownIt.prototype.parse = function (src, env) {
+  env = (env) ? env : {}
   var state = new this.core.State(src, this, env);
 
   this.core.process(state);


### PR DESCRIPTION
The code throws an error if there are references.

    TypeError: Cannot read property 'references' of undefined
        at Array.reference (/Users/thomas/Desktop/es6-shim/node_modules/markdown-it/lib/rules_block/reference.js:182:23)
        at ParserBlock.tokenize (/Users/thomas/Desktop/es6-shim/node_modules/markdown-it/lib/parser_block.js:79:20)
        at ParserBlock.parse (/Users/thomas/Desktop/es6-shim/node_modules/markdown-it/lib/parser_block.js:118:8)
        at Array.block (/Users/thomas/Desktop/es6-shim/node_modules/markdown-it/lib/rules_core/block.js:14:20)
        at Core.process (/Users/thomas/Desktop/es6-shim/node_modules/markdown-it/lib/parser_core.js:51:13)
        at MarkdownIt.parse (/Users/thomas/Desktop/es6-shim/node_modules/markdown-it/lib/index.js:493:13)
        at promiseRipple.processNodes (/Users/thomas/Desktop/es6-shim/test-markdown-it.js:317:23)
        at /Users/thomas/Desktop/es6-shim/promise-ripple.js:13:28
        at tryCatcher (/Users/thomas/Desktop/es6-shim/node_modules/bluebird/js/main/util.js:26:23)
        at ReductionPromiseArray._promiseFulfilled (/Users/thomas/Desktop/es6-shim/node_modules/bluebird/js/main/reduce.js:109:18)
        at Promise._settlePromiseAt (/Users/thomas/Desktop/es6-shim/node_modules/bluebird/js/main/promise.js:582:26)
        at Promise._settlePromises (/Users/thomas/Desktop/es6-shim/node_modules/bluebird/js/main/promise.js:693:14)
        at Async._drainQueue (/Users/thomas/Desktop/es6-shim/node_modules/bluebird/js/main/async.js:123:16)
        at Async._drainQueues (/Users/thomas/Desktop/es6-shim/node_modules/bluebird/js/main/async.js:133:10)
        at Immediate.Async.drainQueues [as _onImmediate] (/Users/thomas/Desktop/es6-shim/node_modules/bluebird/js/main/async.js:15:14)
        at processImmediate [as _immediateCallback] (timers.js:371:17)

Because there's no default sandbox.

More about it here: http://stackoverflow.com/questions/32159530/parse-markdown-reference-with-markdown-it

Just a thought.