### PR TITLE
Added a layer of abstraction so tokens can be directly gotten

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,7 @@ function normalizeLink(url) {
     if (!parsed.protocol || RECODE_HOSTNAME_FOR.indexOf(parsed.protocol) >= 0) {
       try {
         parsed.hostname = punycode.toASCII(parsed.hostname);
-      } catch(er) {}
+      } catch(er) { /**/ }
     }
   }
 
@@ -77,7 +77,7 @@ function normalizeLinkText(url) {
     if (!parsed.protocol || RECODE_HOSTNAME_FOR.indexOf(parsed.protocol) >= 0) {
       try {
         parsed.hostname = punycode.toUnicode(parsed.hostname);
-      } catch(er) {}
+      } catch(er) { /**/ }
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -513,6 +513,15 @@ MarkdownIt.prototype.render = function (src, env) {
   return this.renderer.render(this.parse(src, env), this.options, env);
 };
 
+
+/**
+ * MarkdownIt.renderTokens(src [, env]) -> String
+ * - src (String): source string
+ * - env (Object): environment sandbox
+ *
+ * Render markdown string into an array of html-like tokens.
+ * If you want to render each token separately (for example with React)
+ **/
 MarkdownIt.prototype.renderTokens = function (src, env) {
   env = env || {};
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,7 @@ function normalizeLink(url) {
     if (!parsed.protocol || RECODE_HOSTNAME_FOR.indexOf(parsed.protocol) >= 0) {
       try {
         parsed.hostname = punycode.toASCII(parsed.hostname);
-      } catch (er) { /**/ }
+      } catch(er) {}
     }
   }
 
@@ -77,7 +77,7 @@ function normalizeLinkText(url) {
     if (!parsed.protocol || RECODE_HOSTNAME_FOR.indexOf(parsed.protocol) >= 0) {
       try {
         parsed.hostname = punycode.toUnicode(parsed.hostname);
-      } catch (er) { /**/ }
+      } catch(er) {}
     }
   }
 
@@ -483,7 +483,7 @@ MarkdownIt.prototype.use = function (plugin /*, params, ... */) {
  * AST).
  *
  * `env` is used to pass data between "distributed" rules and return additional
- * metadata like reference info, needed for the renderer. It also can be used to
+ * metadata like reference info, needed for for renderer. It also can be used to
  * inject data in specific cases. Usually, you will be ok to pass `{}`,
  * and then pass updated object to renderer.
  **/
@@ -511,6 +511,12 @@ MarkdownIt.prototype.render = function (src, env) {
   env = env || {};
 
   return this.renderer.render(this.parse(src, env), this.options, env);
+};
+
+MarkdownIt.prototype.renderTokens = function (src, env) {
+  env = env || {};
+
+  return this.renderer.renderTokens(this.parse(src, env), this.options, env);
 };
 
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -28,7 +28,7 @@ default_rules.code_block = function (tokens, idx /*, options, env */) {
 };
 
 
-default_rules.fence = function (tokens, idx, options, env, slf) {
+default_rules.fence = function (tokens, idx, options, env, self) {
   var token = tokens[idx],
       info = token.info ? unescapeAll(token.info).trim() : '',
       langName = '',
@@ -45,13 +45,13 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
     highlighted = escapeHtml(token.content);
   }
 
-  return  '<pre><code' + slf.renderAttrs(token) + '>'
+  return  '<pre><code' + self.renderAttrs(token) + '>'
         + highlighted
         + '</code></pre>\n';
 };
 
 
-default_rules.image = function (tokens, idx, options, env, slf) {
+default_rules.image = function (tokens, idx, options, env, self) {
   var token = tokens[idx];
 
   // "alt" attr MUST be set, even if empty. Because it's mandatory and
@@ -60,9 +60,9 @@ default_rules.image = function (tokens, idx, options, env, slf) {
   // Replace content with actual value
 
   token.attrs[token.attrIndex('alt')][1] =
-    slf.renderInlineAsText(token.children, options, env);
+    self.renderInlineAsText(token.children, options, env);
 
-  return slf.renderToken(tokens, idx, options);
+  return self.renderToken(tokens, idx, options);
 };
 
 
@@ -228,6 +228,16 @@ Renderer.prototype.renderInline = function (tokens, options, env) {
   var type,
       result = '',
       rules = this.rules;
+   
+  return tokens.map(function(token, i) {
+    type = token.type;
+
+    if (typeof rules[type] !== 'undefined') {
+      return rules[type](tokens, i, options, env, this);
+    } else {
+      return this.renderToken(tokens, i, options);
+    }
+  }, this);
 
   for (var i = 0, len = tokens.length; i < len; i++) {
     type = tokens[i].type;
@@ -279,23 +289,30 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
  * this method directly.
  **/
 Renderer.prototype.render = function (tokens, options, env) {
+  return this.renderTokens(tokens, options, env).reduce(function(collector, token) {
+    return collector + token;
+  }, '');
+};
+
+Renderer.prototype.renderTokens = function (tokens, options, env) {
   var i, len, type,
       result = '',
       rules = this.rules;
 
-  for (i = 0, len = tokens.length; i < len; i++) {
-    type = tokens[i].type;
+  return tokens.reduce(function(collector, token, i) {
+    type = token.type;
 
     if (type === 'inline') {
-      result += this.renderInline(tokens[i].children, options, env);
+      console.log('inline: ', this.renderInline(token.children, options, env));
+      return collector.concat(this.renderInline(token.children, options, env));
     } else if (typeof rules[type] !== 'undefined') {
-      result += rules[tokens[i].type](tokens, i, options, env, this);
+      collector.push(rules[type](tokens, i, options, env, this));
+      return collector;
     } else {
-      result += this.renderToken(tokens, i, options, env);
+      collector.push(this.renderToken(tokens, i, options, env));
+      return collector;
     }
-  }
-
-  return result;
+  }.bind(this), []);
 };
 
 module.exports = Renderer;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -238,18 +238,6 @@ Renderer.prototype.renderInline = function (tokens, options, env) {
       return this.renderToken(tokens, i, options);
     }
   }, this);
-
-  for (var i = 0, len = tokens.length; i < len; i++) {
-    type = tokens[i].type;
-
-    if (typeof rules[type] !== 'undefined') {
-      result += rules[type](tokens, i, options, env, this);
-    } else {
-      result += this.renderToken(tokens, i, options);
-    }
-  }
-
-  return result;
 };
 
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -28,7 +28,7 @@ default_rules.code_block = function (tokens, idx /*, options, env */) {
 };
 
 
-default_rules.fence = function (tokens, idx, options, env, self) {
+default_rules.fence = function (tokens, idx, options, env, slf) {
   var token = tokens[idx],
       info = token.info ? unescapeAll(token.info).trim() : '',
       langName = '',
@@ -45,13 +45,13 @@ default_rules.fence = function (tokens, idx, options, env, self) {
     highlighted = escapeHtml(token.content);
   }
 
-  return  '<pre><code' + self.renderAttrs(token) + '>'
+  return  '<pre><code' + slf.renderAttrs(token) + '>'
         + highlighted
         + '</code></pre>\n';
 };
 
 
-default_rules.image = function (tokens, idx, options, env, self) {
+default_rules.image = function (tokens, idx, options, env, slf) {
   var token = tokens[idx];
 
   // "alt" attr MUST be set, even if empty. Because it's mandatory and
@@ -60,9 +60,9 @@ default_rules.image = function (tokens, idx, options, env, self) {
   // Replace content with actual value
 
   token.attrs[token.attrIndex('alt')][1] =
-    self.renderInlineAsText(token.children, options, env);
+    slf.renderInlineAsText(token.children, options, env);
 
-  return self.renderToken(tokens, idx, options);
+  return slf.renderToken(tokens, idx, options);
 };
 
 
@@ -226,17 +226,15 @@ Renderer.prototype.renderToken = function renderToken(tokens, idx, options) {
  **/
 Renderer.prototype.renderInline = function (tokens, options, env) {
   var type,
-      result = '',
       rules = this.rules;
-   
+
   return tokens.map(function(token, i) {
     type = token.type;
 
     if (typeof rules[type] !== 'undefined') {
       return rules[type](tokens, i, options, env, this);
-    } else {
-      return this.renderToken(tokens, i, options);
-    }
+
+    return this.renderToken(tokens, i, options);
   }, this);
 };
 
@@ -293,23 +291,23 @@ Renderer.prototype.render = function (tokens, options, env) {
  * this method directly.
  **/
 Renderer.prototype.renderTokens = function (tokens, options, env) {
-  var i, len, type,
+  var len, type,
       result = '',
       rules = this.rules;
 
   return tokens.reduce(function(collector, token, i) {
     type = token.type;
 
-    if (type === 'inline') {
-      console.log('inline: ', this.renderInline(token.children, options, env));
+    if (type === 'inline')
       return collector.concat(this.renderInline(token.children, options, env));
-    } else if (typeof rules[type] !== 'undefined') {
+
+    if (typeof rules[type] !== 'undefined') {
       collector.push(rules[type](tokens, i, options, env, this));
       return collector;
-    } else {
-      collector.push(this.renderToken(tokens, i, options, env));
-      return collector;
     }
+
+    collector.push(this.renderToken(tokens, i, options, env));
+    return collector;
   }.bind(this), []);
 };
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -294,6 +294,16 @@ Renderer.prototype.render = function (tokens, options, env) {
   }, '');
 };
 
+
+/**
+ * Renderer.renderTokens(tokens, options, env) -> String
+ * - tokens (Array): list on block tokens to renter
+ * - options (Object): params of parser instance
+ * - env (Object): additional data from parsed input (references, for example)
+ *
+ * Takes token stream and generates html-like tokens. Probably, you will never need to call
+ * this method directly.
+ **/
 Renderer.prototype.renderTokens = function (tokens, options, env) {
   var i, len, type,
       result = '',

--- a/test/misc.js
+++ b/test/misc.js
@@ -213,6 +213,13 @@ describe('Misc', function () {
     assert.strictEqual(md.render('[foo](bar)'), '<p><a href="bar" target="_blank">foo</a></p>\n');
   });
 
+  it('Should render tokens into an array', function() {
+    var md = markdownit()
+    
+    console.log(md.renderTokens('foo'));
+    assert.deepEqual(md.renderTokens('foo'), ['<p>', 'foo', '</p>\n']);
+  });
+
 });
 
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -214,10 +214,9 @@ describe('Misc', function () {
   });
 
   it('Should render tokens into an array', function() {
-    var md = markdownit()
-    
-    console.log(md.renderTokens('foo'));
-    assert.deepEqual(md.renderTokens('foo'), ['<p>', 'foo', '</p>\n']);
+    var md = markdownit();
+
+    assert.deepEqual(md.renderTokens('foo'), [ '<p>', 'foo', '</p>\n' ]);
   });
 
 });


### PR DESCRIPTION
This was so I could write a plugin that could render React components.

Upsides: Cleaner code (map/reduce), any other rendering engine that could use objects could take advantage of the abstraction.

Downside: an additional array creation well use up n memory and cause n allocations where n is the number of tokens generated by the parser.

Unfortunately, I can't seem to run the benchmark, because an autolinker module can't be found.