### PR TITLE
Check for the presence of `env` before `env.references`.

### DIFF
--- a/lib/rules_inline/link.js
+++ b/lib/rules_inline/link.js
@@ -95,7 +95,7 @@ module.exports = function link(state, silent) {
     //
     // Link reference
     //
-    if (typeof state.env.references === 'undefined') { return false; }
+    if (typeof state.env === 'undefined' || typeof state.env.references === 'undefined') { return false; }
 
     // [foo]  [bar]
     //      ^^ optional whitespace (can include newlines)


### PR DESCRIPTION
Hi!

The following code failed on my computer with `Cannot read property 'references' of undefined`.

```
md = require('markdown-it')('commonmark');
md.parse("Hello you: [link]");
```

I ended up patching markdown-it as shown in the pull request. To be honest, I haven't been able to write a test to reproduce the bug in your test suite, sorry. I wanted your opinion on the exact fix anyway.