### PR TITLE
adding default_attributes feature to markdown-it renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ var md = require('markdown-it')({
 
   // Highlighter function. Should return escaped HTML,
   // or '' if the source string is not changed and should be escaped externaly.
-  highlight: function (/*str, lang*/) { return ''; }
+  highlight: function (/*str, lang*/) { return ''; },
+  
+  // Configure default attributes for given tags
+  default_attributes:  {"a":[["rel", "nofollow"]]}
 });
 ```
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -134,8 +134,8 @@ function Renderer() {
 Renderer.prototype.renderAttrs = function renderAttrs(token, options) {
   var i, l, result;
 
-  if(('default_attributes' in options) && (token.tag in options.default_attributes)){
-    token.attrs = (token.attrs||[]).concat(options.default_attributes[token.tag]);
+  if (('default_attributes' in options) && (token.tag in options.default_attributes)) {
+    token.attrs = (token.attrs || []).concat(options.default_attributes[token.tag]);
   }
 
   if (!token.attrs) { return ''; }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -45,7 +45,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
     highlighted = escapeHtml(token.content);
   }
 
-  return  '<pre><code' + slf.renderAttrs(token) + '>'
+  return  '<pre><code' + slf.renderAttrs(token, options) + '>'
         + highlighted
         + '</code></pre>\n';
 };
@@ -131,8 +131,12 @@ function Renderer() {
  *
  * Render token attributes to string.
  **/
-Renderer.prototype.renderAttrs = function renderAttrs(token) {
+Renderer.prototype.renderAttrs = function renderAttrs(token, options) {
   var i, l, result;
+
+  if(('default_attributes' in options) && (token.tag in options.default_attributes)){
+    token.attrs = (token.attrs||[]).concat(options.default_attributes[token.tag]);
+  }
 
   if (!token.attrs) { return ''; }
 
@@ -181,7 +185,7 @@ Renderer.prototype.renderToken = function renderToken(tokens, idx, options) {
   result += (token.nesting === -1 ? '</' : '<') + token.tag;
 
   // Encode attributes, e.g. `<img src="foo"`
-  result += this.renderAttrs(token);
+  result += this.renderAttrs(token, options);
 
   // Add a slash for self-closing tags, e.g. `<img src="foo" /`
   if (token.nesting === 0 && options.xhtmlOut) {


### PR DESCRIPTION
Adding a simple way to define default attributes for given tags in the markdown-it configuration.