### PR TITLE
add note about requiring markdown-it

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,8 @@ Prior to continue, make sure you've read:
     block & inline rules are usually faster.
   - Sometime it's enougth to modify renderer only (for example, to add
     header IDs or `target="_blank"` for the links).
+  - Plugins should use passed arguments to access markdown-it. Plugins should 
+    *never* require markdown-it directly.
 2. Search existing
    [plugins](https://www.npmjs.org/browse/keyword/markdown-it-plugin)
    or [rules](https://github.com/markdown-it/markdown-it/tree/master/lib),


### PR DESCRIPTION
I've stumbled upon several plugins ([toc and anchor](https://github.com/MoOx/markdown-it-toc-and-anchor/blob/master/src/index.js#L1), [named headers](https://github.com/leff/markdown-it-named-headers/blob/master/index.js#L4), [anchor](https://github.com/valeriangalliat/markdown-it-anchor/blob/master/index.es6.js#L3)) which require markdown-it directly. In this case, it seems like markdown-it-anchor was the first to require markdown-it, then the others have followed. markdown-it-named-headers doesn't even use `Token`.

Tldr; I think this note is useful for fresh plugin writers.