### PR TITLE
fix table rendering

### DIFF
--- a/lib/common/html_re.js
+++ b/lib/common/html_re.js
@@ -2,27 +2,27 @@
 
 'use strict';
 
-var attr_name     = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
+var attrName     = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
 
 var unquoted      = '[^"\'=<>`\\x00-\\x20]+';
-var single_quoted = "'[^']*'";
-var double_quoted = '"[^"]*"';
+var singleQuoted = "'[^']*'";
+var doubleQuoted = '"[^"]*"';
 
-var attr_value  = '(?:' + unquoted + '|' + single_quoted + '|' + double_quoted + ')';
+var attrValue  = '(?:' + unquoted + '|' + singleQuoted + '|' + doubleQuoted + ')';
 
-var attribute   = '(?:\\s+' + attr_name + '(?:\\s*=\\s*' + attr_value + ')?)';
+var attribute   = '(?:\\s+' + attrName + '(?:\\s*=\\s*' + attrValue + ')?)';
 
-var open_tag    = '<[A-Za-z][A-Za-z0-9\\-]*' + attribute + '*\\s*\\/?>';
+var openTag    = '<[A-Za-z][A-Za-z0-9\\-]*' + attribute + '*\\s*\\/?>';
 
-var close_tag   = '<\\/[A-Za-z][A-Za-z0-9\\-]*\\s*>';
+var closeTag   = '<\\/[A-Za-z][A-Za-z0-9\\-]*\\s*>';
 var comment     = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->';
 var processing  = '<[?].*?[?]>';
 var declaration = '<![A-Z]+\\s+[^>]*>';
 var cdata       = '<!\\[CDATA\\[[\\s\\S]*?\\]\\]>';
 
-var HTML_TAG_RE = new RegExp('^(?:' + open_tag + '|' + close_tag + '|' + comment +
+var HTML_TAG_RE = new RegExp('^(?:' + openTag + '|' + closeTag + '|' + comment +
                         '|' + processing + '|' + declaration + '|' + cdata + ')');
-var HTML_OPEN_CLOSE_TAG_RE = new RegExp('^(?:' + open_tag + '|' + close_tag + ')');
+var HTML_OPEN_CLOSE_TAG_RE = new RegExp('^(?:' + openTag + '|' + closeTag + ')');
 
 module.exports.HTML_TAG_RE = HTML_TAG_RE;
 module.exports.HTML_OPEN_CLOSE_TAG_RE = HTML_OPEN_CLOSE_TAG_RE;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-// Main perser class
+// Main parser class
 
 'use strict';
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -15,20 +15,20 @@ var escapeHtml      = require('./common/utils').escapeHtml;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-var default_rules = {};
+var defaultRules = {};
 
 
-default_rules.code_inline = function (tokens, idx /*, options, env */) {
+defaultRules.code_inline = function (tokens, idx /*, options, env */) {
   return '<code>' + escapeHtml(tokens[idx].content) + '</code>';
 };
 
 
-default_rules.code_block = function (tokens, idx /*, options, env */) {
+defaultRules.code_block = function (tokens, idx /*, options, env */) {
   return '<pre><code>' + escapeHtml(tokens[idx].content) + '</code></pre>\n';
 };
 
 
-default_rules.fence = function (tokens, idx, options, env, slf) {
+defaultRules.fence = function (tokens, idx, options, env, slf) {
   var token = tokens[idx],
       info = token.info ? unescapeAll(token.info).trim() : '',
       langName = '',
@@ -55,7 +55,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
 };
 
 
-default_rules.image = function (tokens, idx, options, env, slf) {
+defaultRules.image = function (tokens, idx, options, env, slf) {
   var token = tokens[idx];
 
   // "alt" attr MUST be set, even if empty. Because it's mandatory and
@@ -70,23 +70,23 @@ default_rules.image = function (tokens, idx, options, env, slf) {
 };
 
 
-default_rules.hardbreak = function (tokens, idx, options /*, env */) {
+defaultRules.hardbreak = function (tokens, idx, options /*, env */) {
   return options.xhtmlOut ? '<br />\n' : '<br>\n';
 };
-default_rules.softbreak = function (tokens, idx, options /*, env */) {
+defaultRules.softbreak = function (tokens, idx, options /*, env */) {
   return options.breaks ? (options.xhtmlOut ? '<br />\n' : '<br>\n') : '\n';
 };
 
 
-default_rules.text = function (tokens, idx /*, options, env */) {
+defaultRules.text = function (tokens, idx /*, options, env */) {
   return escapeHtml(tokens[idx].content);
 };
 
 
-default_rules.html_block = function (tokens, idx /*, options, env */) {
+defaultRules.html_block = function (tokens, idx /*, options, env */) {
   return tokens[idx].content;
 };
-default_rules.html_inline = function (tokens, idx /*, options, env */) {
+defaultRules.html_inline = function (tokens, idx /*, options, env */) {
   return tokens[idx].content;
 };
 
@@ -117,7 +117,7 @@ function Renderer() {
    * Each rule is called as independed static function with fixed signature:
    *
    * ```javascript
-   * function my_token_render(tokens, idx, options, env, renderer) {
+   * function myTokenRender(tokens, idx, options, env, renderer) {
    *   // ...
    *   return renderedHTML;
    * }
@@ -126,7 +126,7 @@ function Renderer() {
    * See [source code](https://github.com/markdown-it/markdown-it/blob/master/lib/renderer.js)
    * for more details and examples.
    **/
-  this.rules = assign({}, default_rules);
+  this.rules = assign({}, defaultRules);
 }
 
 

--- a/lib/rules_block/html_block.js
+++ b/lib/rules_block/html_block.js
@@ -3,7 +3,7 @@
 'use strict';
 
 
-var block_names = require('../common/html_blocks');
+var blockNames = require('../common/html_blocks');
 var HTML_OPEN_CLOSE_TAG_RE = require('../common/html_re').HTML_OPEN_CLOSE_TAG_RE;
 
 // An array of opening and corresponding closing sequences for html tags,
@@ -15,12 +15,12 @@ var HTML_SEQUENCES = [
   [ /^<\?/,         /\?>/,   true ],
   [ /^<![A-Z]/,     />/,     true ],
   [ /^<!\[CDATA\[/, /\]\]>/, true ],
-  [ new RegExp('^</?(' + block_names.join('|') + ')(?=(\\s|/?>|$))', 'i'), /^$/, true ],
+  [ new RegExp('^</?(' + blockNames.join('|') + ')(?=(\\s|/?>|$))', 'i'), /^$/, true ],
   [ new RegExp(HTML_OPEN_CLOSE_TAG_RE.source + '\\s*$'),  /^$/, false ]
 ];
 
 
-module.exports = function html_block(state, startLine, endLine, silent) {
+module.exports = function htmlBlock(state, startLine, endLine, silent) {
   var i, nextLine, token, lineText,
       pos = state.bMarks[startLine] + state.tShift[startLine],
       max = state.eMarks[startLine];

--- a/lib/rules_block/state_block.js
+++ b/lib/rules_block/state_block.js
@@ -7,7 +7,7 @@ var isSpace = require('../common/utils').isSpace;
 
 
 function StateBlock(src, md, env, tokens) {
-  var ch, s, start, pos, len, indent, offset, indent_found;
+  var ch, s, start, pos, len, indent, offset, indentFound;
 
   this.src = src;
 
@@ -44,12 +44,12 @@ function StateBlock(src, md, env, tokens) {
   // Create caches
   // Generate markers.
   s = this.src;
-  indent_found = false;
+  indentFound = false;
 
   for (start = pos = indent = offset = 0, len = s.length; pos < len; pos++) {
     ch = s.charCodeAt(pos);
 
-    if (!indent_found) {
+    if (!indentFound) {
       if (isSpace(ch)) {
         indent++;
 
@@ -60,7 +60,7 @@ function StateBlock(src, md, env, tokens) {
         }
         continue;
       } else {
-        indent_found = true;
+        indentFound = true;
       }
     }
 
@@ -71,7 +71,7 @@ function StateBlock(src, md, env, tokens) {
       this.tShift.push(indent);
       this.sCount.push(offset);
 
-      indent_found = false;
+      indentFound = false;
       indent = 0;
       offset = 0;
       start = pos + 1;

--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -143,9 +143,12 @@ module.exports = function table(state, startLine, endLine, silent) {
   for (nextLine = startLine + 2; nextLine < endLine; nextLine++) {
     if (state.sCount[nextLine] < state.blkIndent) { break; }
 
-    lineText = getLine(state, nextLine).trim();
+    lineText = getLine(state, nextLine);
     if (lineText.indexOf('|') === -1) { break; }
-    columns = escapedSplit(lineText.replace(/^\||\|$/g, ''));
+
+    // keep spaces at beginning of line to indicate an empty first cell, but
+    // strip trailing whitespace
+    columns = escapedSplit(lineText.replace(/^\||\|\s*$/g, ''));
 
     token = state.push('tr_open', 'tr', 1);
     for (i = 0; i < columnCount; i++) {

--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -55,7 +55,7 @@ function escapedSplit(str) {
 
 module.exports = function table(state, startLine, endLine, silent) {
   var ch, lineText, pos, i, nextLine, columns, columnCount, token,
-      aligns, t, tableLines, tbodyLines;
+      aligns, t, tableLines, tbodyLines, len;
 
   // should have at least three lines
   if (startLine + 2 > endLine) { return false; }
@@ -151,7 +151,8 @@ module.exports = function table(state, startLine, endLine, silent) {
     columns = escapedSplit(lineText.replace(/^\||\|\s*$/g, ''));
 
     token = state.push('tr_open', 'tr', 1);
-    for (i = 0; i < columnCount; i++) {
+    len = Math.max(columns.length, columnCount);
+    for (i = 0; i < len; i++) {
       token          = state.push('td_open', 'td', 1);
       if (aligns[i]) {
         token.attrs  = [ [ 'style', 'text-align:' + aligns[i] ] ];

--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -33,7 +33,7 @@ function replaceFn(match, name) {
   return SCOPED_ABBR[name.toLowerCase()];
 }
 
-function replace_scoped(inlineTokens) {
+function replaceScoped(inlineTokens) {
   var i, token;
 
   for (i = inlineTokens.length - 1; i >= 0; i--) {
@@ -44,7 +44,7 @@ function replace_scoped(inlineTokens) {
   }
 }
 
-function replace_rare(inlineTokens) {
+function replaceRare(inlineTokens) {
   var i, token;
 
   for (i = inlineTokens.length - 1; i >= 0; i--) {
@@ -78,11 +78,11 @@ module.exports = function replace(state) {
     if (state.tokens[blkIdx].type !== 'inline') { continue; }
 
     if (SCOPED_ABBR_TEST_RE.test(state.tokens[blkIdx].content)) {
-      replace_scoped(state.tokens[blkIdx].children);
+      replaceScoped(state.tokens[blkIdx].children);
     }
 
     if (RARE_RE.test(state.tokens[blkIdx].content)) {
-      replace_rare(state.tokens[blkIdx].children);
+      replaceRare(state.tokens[blkIdx].children);
     }
 
   }

--- a/lib/rules_core/smartquotes.js
+++ b/lib/rules_core/smartquotes.js
@@ -16,7 +16,7 @@ function replaceAt(str, index, ch) {
   return str.substr(0, index) + ch + str.substr(index + 1);
 }
 
-function process_inlines(tokens, state) {
+function processInlines(tokens, state) {
   var i, token, text, t, pos, max, thisLevel, item, lastChar, nextChar,
       isLastPunctChar, isNextPunctChar, isLastWhiteSpace, isNextWhiteSpace,
       canOpen, canClose, j, isSingle, stack, openQuote, closeQuote;
@@ -188,6 +188,6 @@ module.exports = function smartquotes(state) {
       continue;
     }
 
-    process_inlines(state.tokens[blkIdx].children, state);
+    processInlines(state.tokens[blkIdx].children, state);
   }
 };

--- a/lib/rules_inline/emphasis.js
+++ b/lib/rules_inline/emphasis.js
@@ -50,8 +50,8 @@ module.exports.tokenize = function emphasis(state, silent) {
       // Boolean flags that determine if this delimiter could open or close
       // an emphasis.
       //
-      open:   scanned.can_open,
-      close:  scanned.can_close
+      open:   scanned.canOpen,
+      close:  scanned.canClose
     });
   }
 

--- a/lib/rules_inline/state_inline.js
+++ b/lib/rules_inline/state_inline.js
@@ -67,11 +67,11 @@ StateInline.prototype.push = function (type, tag, nesting) {
 //  - canSplitWord - determine if these markers can be found inside a word
 //
 StateInline.prototype.scanDelims = function (start, canSplitWord) {
-  var pos = start, lastChar, nextChar, count, can_open, can_close,
+  var pos = start, lastChar, nextChar, count, canOpen, canClose,
       isLastWhiteSpace, isLastPunctChar,
       isNextWhiteSpace, isNextPunctChar,
-      left_flanking = true,
-      right_flanking = true,
+      leftFlanking = true,
+      rightFlanking = true,
       max = this.posMax,
       marker = this.src.charCodeAt(start);
 
@@ -92,32 +92,32 @@ StateInline.prototype.scanDelims = function (start, canSplitWord) {
   isNextWhiteSpace = isWhiteSpace(nextChar);
 
   if (isNextWhiteSpace) {
-    left_flanking = false;
+    leftFlanking = false;
   } else if (isNextPunctChar) {
     if (!(isLastWhiteSpace || isLastPunctChar)) {
-      left_flanking = false;
+      leftFlanking = false;
     }
   }
 
   if (isLastWhiteSpace) {
-    right_flanking = false;
+    rightFlanking = false;
   } else if (isLastPunctChar) {
     if (!(isNextWhiteSpace || isNextPunctChar)) {
-      right_flanking = false;
+      rightFlanking = false;
     }
   }
 
   if (!canSplitWord) {
-    can_open  = left_flanking  && (!right_flanking || isLastPunctChar);
-    can_close = right_flanking && (!left_flanking  || isNextPunctChar);
+    canOpen  = leftFlanking  && (!rightFlanking || isLastPunctChar);
+    canClose = rightFlanking && (!leftFlanking  || isNextPunctChar);
   } else {
-    can_open  = left_flanking;
-    can_close = right_flanking;
+    canOpen  = leftFlanking;
+    canClose = rightFlanking;
   }
 
   return {
-    can_open:  can_open,
-    can_close: can_close,
+    canOpen:  canOpen,
+    canClose: canClose,
     length:    count
   };
 };

--- a/lib/rules_inline/strikethrough.js
+++ b/lib/rules_inline/strikethrough.js
@@ -36,8 +36,8 @@ module.exports.tokenize = function strikethrough(state, silent) {
       token:  state.tokens.length - 1,
       level:  state.level,
       end:    -1,
-      open:   scanned.can_open,
-      close:  scanned.can_close
+      open:   scanned.canOpen,
+      close:  scanned.canClose
     });
   }
 

--- a/test/fixtures/markdown-it/tables.txt
+++ b/test/fixtures/markdown-it/tables.txt
@@ -470,3 +470,35 @@ Allow one-column tables (issue #171):
 </tbody>
 </table>
 .
+
+
+Allow tables with missing values:
+.
+0,0 | 0,1 | 0,2
+--- | --- | ---
+1,0 |     | 1,2
+    | 2,1 |
+
+.
+<table>
+<thead>
+<tr>
+<th>0,0</th>
+<th>0,1</th>
+<th>0,2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1,0</td>
+<td></td>
+<td>1,2</td>
+</tr>
+<tr>
+<td></td>
+<td>2,1</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+.

--- a/test/fixtures/markdown-it/tables.txt
+++ b/test/fixtures/markdown-it/tables.txt
@@ -401,7 +401,7 @@ Should be parsed before code blocks:
 .
 
 
-An amount of rows might be different across the table (issue #171):
+Allow tables with extra cells in a row outside of thead:
 .
 | 1 | 2 |
 | :-----: |  :-----: |  :-----: |
@@ -418,6 +418,8 @@ An amount of rows might be different across the table (issue #171):
 <tr>
 <td style="text-align:center">3</td>
 <td style="text-align:center">4</td>
+<td style="text-align:center">5</td>
+<td>6</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
I'm working on replacing [marked](https://github.com/chjj/marked) with markdown-it in a formatting tool called [tidy-markdown](https://github.com/slang800/tidy-markdown) (to conform to the commonmark standard).

This PR does 3 things (see commit messages):

- fix inconsistent variable naming, as a follow-up to https://github.com/markdown-it/markdown-it/pull/220#issuecomment-203803325
- fix handling for empty rows at the beginning of the table
- fix truncation of cells from tbody rows that are longer than the thead row

That last thing this PR does is in opposition to what #171 asked for, so I'll elaborate on the reason for opposing #171 and matching the way that marked handles tables...

The way that GitHub.com does this (truncating all rows that are longer than the thead row) is stupid. It hides content that could be important to readers, without so much as a parser error. And that can be a pain when you're not carefully checking what your markdown looks like after compilation. For example, an extra cell jutting out of an otherwise rectangular table, or a missing header is an easy error to spot, while a column missing still leaves the table looking correct and orderly.

Even if you are looking at the output in a graphical/rendered form while you're editing, it's annoying to start a table cell in a new column and not be able to see what you are typing until you add a header for that column.