### PR TITLE
Fixes #246, HTML Escaping alt-tag twice.

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -258,12 +258,11 @@ Renderer.prototype.renderInline = function (tokens, options, env) {
  * instead of simple escaping.
  **/
 Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
-  var result = '',
-      rules = this.rules;
+  var result = '';
 
   for (var i = 0, len = tokens.length; i < len; i++) {
     if (tokens[i].type === 'text') {
-      result += rules.text(tokens, i, options, env, this);
+      result += tokens[i].content;
     } else if (tokens[i].type === 'image') {
       result += this.renderInlineAsText(tokens[i].children, options, env);
     }

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -1,3 +1,17 @@
+Issue #246.  Double escaping in ALT
+.
+![&](#)
+.
+<p><img src="#" alt="&amp;"></p>
+.
+
+Strip markdown in ALT tags
+.
+![*strip* [markdown __in__ alt](#)](#)
+.
+<p><img src="#" alt="strip markdown in alt"></p>
+.
+
 Issue #55:
 .
 ![test]


### PR DESCRIPTION
The function `renderInlineAsText` is only call for image alt tags.  Sending the tags through `rules.text` performs and HTML escape.  Later on in the logic, this tag is sent to `renderAttrs` which escapes the alt tag again.  The result is a bug such as:

Input: `![&](#)`
Render: `<p><img src="#" alt="&amp;amp;"></p>`