### PR TITLE
Add an attrGet method to Token

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -164,6 +164,20 @@ Token.prototype.attrSet = function attrSet(name, value) {
 
 
 /**
+ * Token.attrGet(name)
+ *
+ * Get the value of attribute `name`, or null if it does not exist.
+ **/
+Token.prototype.attrGet = function attrGet(name) {
+  var idx = this.attrIndex(name), value = null;
+  if (idx >= 0) {
+    value = this.attrs[idx][1];
+  }
+  return value;
+};
+
+
+/**
  * Token.attrJoin(name, value)
  *
  * Join value to existing attribute via space. Or create new attribute if not

--- a/test/misc.js
+++ b/test/misc.js
@@ -357,4 +357,17 @@ describe('Token attributes', function () {
       '<pre><code class="bar"></code></pre>\n'
     );
   });
+
+  it('.attrGet', function () {
+    var md = markdownit();
+
+    var tokens = md.parse('```'),
+        t = tokens[0];
+
+    assert.strictEqual(t.attrGet('myattr'), null);
+
+    t.attrSet('myattr', 'myvalue');
+
+    assert.strictEqual(t.attrGet('myattr'), 'myvalue');
+  });
 });


### PR DESCRIPTION
Since accessing attributes on tokens isn't entirely trivial, it might make sense to make it easy for token-consuming code to get a specific attribute. It certainly would help in ProseMirror, where I'm currently exporting my own utility for this purpose. Since there were already a few different `attr_` methods, I hope one more is okay.