### PR TITLE
Add shallow cloning for Tokens to preserve the AST after render

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -29,7 +29,10 @@ default_rules.code_block = function (tokens, idx /*, options, env */) {
 
 
 default_rules.fence = function (tokens, idx, options, env, slf) {
-  var token = tokens[idx],
+  // We will make modifications of the attributes object of this
+  // token while processing, so we obtain a shallow clone as to
+  // prevent modifying the token in the token list.
+  var token = tokens[idx].clone(),
       info = token.info ? unescapeAll(token.info).trim() : '',
       langName = '',
       highlighted;

--- a/lib/token.js
+++ b/lib/token.js
@@ -194,4 +194,28 @@ Token.prototype.attrJoin = function attrJoin(name, value) {
 };
 
 
+/**
+ * Token.clone()
+ *
+ * Obtain a shallow clone of the token.  You can use this while rendering to
+ * prevent modifying the token list while rendering.
+ */
+
+Token.prototype.clone = function clone() {
+  var token = new Token(this.type, this.tag, this.nesting);
+
+  token.attrs = this.attrs;
+  token.level = this.level;
+  token.children = this.children;
+  token.content = this.content;
+  token.map = this.map;
+  token.markup = this.markup;
+  token.info = this.info;
+  token.meta = this.meta;
+  token.block = this.block;
+  token.hidden = this.hidden;
+
+  return token;
+};
+
 module.exports = Token;


### PR DESCRIPTION
## About

This is a small patch request to keep to tokens list clean while rendering.  Here is an illustration of the issue.

Source:

``` javascript
var mystr = '``` javascript \n if (foo) { bar; } \n ```';
var tokens = md.parse(mystr, md.options);

console.log(md.renderer.render(tokens, md.options, {}));
console.log(md.renderer.render(tokens, md.options, {}));
```

Before pull request:
```
'<pre><code class="language-javascript"> if (foo) { bar; } \n</code></pre>\n'
'<pre><code class="language-javascript language-javascript"> if (foo) { bar; } \n</code></pre>\n'
```

We see that `renderer.render` will modify the token attributes while processing so if you
feed the token list to `renderer.render` again you will see this attribute twice.

After pull request:
```
'<pre><code class="language-javascript"> if (foo) { bar; } \n</code></pre>\n'
'<pre><code class="language-javascript"> if (foo) { bar; } \n</code></pre>\n'
```

## Application

Markdown-it will become to default markdown rendering engine for vscode 1.3 being released early July it appears.  It allows for a live rendering of markdown as you type.  Instead of re-rendering the entire markdown file, I felt that it would be a worth-while experiment to see if there are cases in which you could only render what has been updated in certain situations.  Please see #258 for more details.

## Benchmark impacts

Before pull request:
```
Sample: block-fences.md (72 bytes)
 > commonmark-reference x 80,532 ops/sec ±0.24% (86 runs sampled)
 > current x 172,560 ops/sec ±1.13% (86 runs sampled)
 > current-commonmark x 133,014 ops/sec ±0.75% (91 runs sampled)
 > markdown-it-2.2.1-commonmark x 182,824 ops/sec ±1.23% (85 runs sampled)
 > marked-0.3.2 x 309,737 ops/sec ±0.94% (88 runs sampled)
```

After pull request:
```
Sample: block-fences.md (72 bytes)
 > commonmark-reference x 77,697 ops/sec ±0.26% (90 runs sampled)
 > current x 173,375 ops/sec ±1.05% (82 runs sampled)
 > current-commonmark x 180,919 ops/sec ±1.28% (91 runs sampled)
 > markdown-it-2.2.1-commonmark x 174,600 ops/sec ±0.95% (88 runs sampled)
 > marked-0.3.2 x 296,704 ops/sec ±0.92% (82 runs sampled)
```

It appears to have minimal impact on fenced code blocks.

