### PR TITLE
code renderer: do not render double space before attrs

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -19,20 +19,18 @@ var default_rules = {};
 
 
 default_rules.code_inline = function (tokens, idx, options, env, slf) {
-  var token = tokens[idx],
-      attrs = slf.renderAttrs(token);
+  var token = tokens[idx];
 
-  return  '<code' + (attrs ? ' ' + attrs : '') + '>' +
+  return  '<code' + slf.renderAttrs(token) + '>' +
           escapeHtml(tokens[idx].content) +
           '</code>';
 };
 
 
 default_rules.code_block = function (tokens, idx, options, env, slf) {
-  var token = tokens[idx],
-      attrs = slf.renderAttrs(token);
+  var token = tokens[idx];
 
-  return  '<pre' + (attrs ? ' ' + attrs : '') + '><code>' +
+  return  '<pre' + slf.renderAttrs(token) + '><code>' +
           escapeHtml(tokens[idx].content) +
           '</code></pre>\n';
 };


### PR DESCRIPTION
[`renderAttrs`](https://github.com/markdown-it/markdown-it/blob/master/lib/renderer.js#L179) already adds a space before attributes, and defaults to `''`.

Before:

    <code  class="language-python">for i in range(10):</code>

Now:

    <code class="language-python">for i in range(10):</code>