### PR TITLE
fence renderer: fix concat of class array

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -68,7 +68,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
     if (i < 0) {
       tmpAttrs.push([ 'class', options.langPrefix + langName ]);
     } else {
-      tmpAttrs[i] += ' ' + options.langPrefix + langName;
+      tmpAttrs[i][1] += ' ' + options.langPrefix + langName;
     }
 
     // Fake token just to render attributes


### PR DESCRIPTION
Before:

    <pre c="l"><code>...

Now:

    <pre class="someClass language-python><code>...

Bug introduced in b7c868b64b710c8e706191d89a6dd80fcbbc9166