### PR TITLE
fallback to reference if a link is not valid

### DIFF
--- a/lib/rules_inline/link.js
+++ b/lib/rules_inline/link.js
@@ -20,7 +20,8 @@ module.exports = function link(state, silent) {
       href = '',
       oldPos = state.pos,
       max = state.posMax,
-      start = state.pos;
+      start = state.pos,
+      parseReference = true;
 
   if (state.src.charCodeAt(state.pos) !== 0x5B/* [ */) { return false; }
 
@@ -35,6 +36,9 @@ module.exports = function link(state, silent) {
     //
     // Inline link
     //
+
+    // might have found a valid shortcut link, disable reference parsing
+    parseReference = false;
 
     // [link](  <href>  "title"  )
     //        ^^ skipping these spaces
@@ -84,11 +88,13 @@ module.exports = function link(state, silent) {
     }
 
     if (pos >= max || state.src.charCodeAt(pos) !== 0x29/* ) */) {
-      state.pos = oldPos;
-      return false;
+      // parsing a valid shortcut link failed, fallback to reference
+      parseReference = true;
     }
     pos++;
-  } else {
+  }
+
+  if (parseReference) {
     //
     // Link reference
     //


### PR DESCRIPTION
This commit makes martdown-it pass a new example introduced in https://github.com/jgm/CommonMark/commit/cfc84164475d3bec8be9482c21a705adc93a54f5

```
[foo](not a link)

[foo]: /url1
.
<p><a href="/url1">foo</a>(not a link)</p>
```

Ref: https://github.com/jgm/CommonMark/issues/427