### PR TITLE
Add Output Option to CLI

### DIFF
--- a/bin/markdown-it.js
+++ b/bin/markdown-it.js
@@ -42,6 +42,11 @@ cli.addArgument([ 'file' ], {
   defaultValue: '-'
 });
 
+cli.addArgument([ '-o', '--output' ], {
+  help: 'File to write',
+  defaultValue: '-'
+});
+
 var options = cli.parseArgs();
 
 
@@ -99,5 +104,10 @@ readFile(options.file, 'utf8', function (err, input) {
     process.exit(1);
   }
 
-  process.stdout.write(output);
+  if (options.output === '-') {
+    // write to stdout
+    process.stdout.write(output);
+  } else {
+    fs.writeFileSync(options.output, output);
+  }
 });


### PR DESCRIPTION
Adds an option to specify the output file when using markdown-it from the command line.

I'm on the VScode team and in our docs, we currently recommend that users install marked for converting markdown to html: https://code.visualstudio.com/Docs/languages/markdown#_compiling-markdown-into-html . I'd like to use markdown-it in this example instead, but correctly setting up a task to use markdown-it this is not as easy as it is with marked. Having a command line output file option fixes this