### PR TITLE
Update hyperlinks to GFM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ If you are going to write plugins - take a look at
 
 Embedded (enabled by default):
 
-- [Tables](https://help.github.com/articles/github-flavored-markdown/#tables) (GFM)
-- [Strikethrough](https://help.github.com/articles/github-flavored-markdown/#strikethrough) (GFM)
+- [Tables](https://help.github.com/articles/organizing-information-with-tables/) (GFM)
+- [Strikethrough](https://help.github.com/articles/basic-writing-and-formatting-syntax/#styling-text) (GFM)
 
 Via plugins:
 


### PR DESCRIPTION
I updated the links to GitHub help docs so they go to the proper GFM feature.