### PR TITLE
add LF to an empty blockquote rendering (cosmetic)

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -236,6 +236,9 @@ Renderer.prototype.renderToken = function renderToken(tokens, idx, options) {
           //
           needLf = false;
 
+        } else if (nextToken.tag === 'blockquote' && nextToken.tag === token.tag) {
+          // in spec.txt blockquote wants \n inside
+
         } else if (nextToken.nesting === -1 && nextToken.tag === token.tag) {
           // Opening tag + closing tag of the same type. E.g. `<li></li>`.
           //

--- a/test/commonmark.js
+++ b/test/commonmark.js
@@ -6,11 +6,6 @@ var load   = require('markdown-it-testgen').load;
 var assert = require('chai').assert;
 
 
-function normalize(text) {
-  return text.replace(/<blockquote>\n<\/blockquote>/g, '<blockquote></blockquote>');
-}
-
-
 function generate(path, md) {
   load(path, function (data) {
     data.meta = data.meta || {};
@@ -20,7 +15,7 @@ function generate(path, md) {
     (data.meta.skip ? describe.skip : describe)(desc, function () {
       data.fixtures.forEach(function (fixture) {
         it(fixture.header ? fixture.header : 'line ' + (fixture.first.range[0] - 1), function () {
-          assert.strictEqual(md.render(fixture.first.text), normalize(fixture.second.text));
+          assert.strictEqual(md.render(fixture.first.text), fixture.second.text);
         });
       });
     });

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -351,7 +351,8 @@ test
 > [foo]: bar
 [foo]
 .
-<blockquote></blockquote>
+<blockquote>
+</blockquote>
 <p><a href="bar">foo</a></p>
 .
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -291,7 +291,7 @@ describe('maxNesting', function () {
     var md = markdownit({ maxNesting: 2 });
     assert.strictEqual(
       md.render('>foo\n>>bar\n>>>baz'),
-      '<blockquote>\n<p>foo</p>\n<blockquote></blockquote>\n</blockquote>\n'
+      '<blockquote>\n<p>foo</p>\n<blockquote>\n</blockquote>\n</blockquote>\n'
     );
   });
 


### PR DESCRIPTION
This way it's more consistent with the reference rendering and does not require a special treatment of spec.txt for testing.