### PR TITLE
better check for property 'references' in js object

### DIFF
--- a/lib/rules_block/reference.js
+++ b/lib/rules_block/reference.js
@@ -183,7 +183,9 @@ module.exports = function reference(state, startLine, _endLine, silent) {
   // Reference can not terminate anything. This check is for safety only.
   /*istanbul ignore if*/
   if (silent) { return true; }
-
+  if (typeof state.env === 'undefined') {
+    state.env = {};
+  }
   if (typeof state.env.references === 'undefined') {
     state.env.references = {};
   }

--- a/lib/rules_inline/image.js
+++ b/lib/rules_inline/image.js
@@ -95,7 +95,7 @@ module.exports = function image(state, silent) {
     //
     // Link reference
     //
-    if (typeof state.env.references === 'undefined') { return false; }
+    if (typeof state.env === 'undefined' || typeof state.env.references === 'undefined') { return false; }
 
     if (pos < max && state.src.charCodeAt(pos) === 0x5B/* [ */) {
       start = pos + 1;

--- a/lib/rules_inline/link.js
+++ b/lib/rules_inline/link.js
@@ -98,7 +98,7 @@ module.exports = function link(state, silent) {
     //
     // Link reference
     //
-    if (typeof state.env.references === 'undefined') { return false; }
+    if (typeof state.env === 'undefined' || typeof state.env.references === 'undefined') { return false; }
 
     if (pos < max && state.src.charCodeAt(pos) === 0x5B/* [ */) {
       start = pos + 1;


### PR DESCRIPTION
fix for javascript error 'Cannot read property "references" from
undefined'