### PR TITLE
Benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 demo/
 apidoc/
 *.log
+.DS_Store

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -16,6 +16,7 @@ var IMPLS = [];
 
 
 fs.readdirSync(IMPLS_DIRECTORY).sort().forEach(function (name) {
+  if (name === '.DS_Store') { return; }
   var file = path.join(IMPLS_DIRECTORY, name);
   var code = require(file);
 

--- a/benchmark/implementations/commonmark-reference/index.js
+++ b/benchmark/implementations/commonmark-reference/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var commonmark = require('../../extra/lib/node_modules/commonmark');
+var commonmark = require('commonmark');
 var parser = new commonmark.Parser();
 var renderer = new commonmark.HtmlRenderer();
 

--- a/benchmark/implementations/markdown-it-2.2.1-commonmark/index.js
+++ b/benchmark/implementations/markdown-it-2.2.1-commonmark/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var md = require('../../extra/lib/node_modules/markdown-it')('commonmark');
+var md = require('markdown-it')('commonmark');
 
 exports.run = function (data) {
   return md.render(data);

--- a/benchmark/implementations/marked/index.js
+++ b/benchmark/implementations/marked/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var marked = require('../../extra/lib/node_modules/marked');
+var marked = require('marked');
 
 exports.run = function (data) {
   return marked(data);


### PR DESCRIPTION
Fix `./benchmark/benchmark.js`. Currently errors with:

```
module.js:471
    throw err;
    ^

Error: Cannot find module '../../extra/lib/node_modules/commonmark'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/arve/git/markdown-it/benchmark/implementations/commonmark-reference/index.js:3:18)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```

Also ignores `.DS_Store` files, which Mac OS X adds to directories when browsing with Finder. You may ignore 6b6c084 if you do not care about Mac dev users.