### PR TITLE
Fixed crash when env is not defined

### DIFF
--- a/lib/rules_inline/link.js
+++ b/lib/rules_inline/link.js
@@ -98,7 +98,7 @@ module.exports = function link(state, silent) {
     //
     // Link reference
     //
-    if (typeof state.env.references === 'undefined') { return false; }
+    if (!state.env || typeof state.env.references === 'undefined') { return false; }
 
     if (pos < max && state.src.charCodeAt(pos) === 0x5B/* [ */) {
       start = pos + 1;


### PR DESCRIPTION
Previously, this code:

````js
const text = `
Here's a footnote [^1].

[^1]: Footnote text goes here.
`;

const md = require('markdown-it')();
const tokens = md.parse(text);
````

would result in this exception:

````
    if (typeof state.env.references === 'undefined') { return false; }
                        ^

TypeError: Cannot read property 'references' of undefined
    at Array.link (.../lib/rules_inline/link.js:101:25)
    at ParserInline.tokenize (.../lib/parser_inline.js:135:22)
    at ParserInline.parse (.../lib/parser_inline.js:163:8)
    at Array.inline (.../lib/rules_core/inline.js:10:23)
    at Core.process (.../lib/parser_core.js:51:13)
    at MarkdownIt.parse (.../lib/index.js:523:13)
````

With this fix, the footnote is treated as regular text and rendered as such.