### PR TITLE
add punycode to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "entities": "~1.1.1",
     "linkify-it": "^2.0.0",
     "mdurl": "^1.0.1",
+    "punycode": "^2.1.1",
     "uc.micro": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
`punycode` is required in `/lib/index.js` but it's not declared in the package.json.

This is an issue for me because I'm using rollup to bundle my library and it can't find `punycode` since it's not a declared dependency and isn't in my `node_modules/`.