### PR TITLE
fix: check if state.env is undefined

### DIFF
--- a/lib/rules_inline/link.js
+++ b/lib/rules_inline/link.js
@@ -98,7 +98,7 @@ module.exports = function link(state, silent) {
     //
     // Link reference
     //
-    if (typeof state.env.references === 'undefined') { return false; }
+    if (typeof state.env === 'undefined' || typeof state.env.references === 'undefined') { return false; }
 
     if (pos < max && state.src.charCodeAt(pos) === 0x5B/* [ */) {
       start = pos + 1;


### PR DESCRIPTION
This was throwing an error when used from https://github.com/gsuitedevs/md2googleslides