### PR TITLE
Option to turn on smartquotes without typographer

### DIFF
--- a/lib/rules_core/smartquotes.js
+++ b/lib/rules_core/smartquotes.js
@@ -181,7 +181,7 @@ module.exports = function smartquotes(state) {
   /*eslint max-depth:0*/
   var blkIdx;
 
-  if (!state.md.options.typographer) { return; }
+  if (!state.md.options.typographer && !state.md.options.smartQuotes) { return; }
 
   for (blkIdx = state.tokens.length - 1; blkIdx >= 0; blkIdx--) {
 


### PR DESCRIPTION
I think that smartquotes are cool but I don't like the other replacements. Wouldn't it be nice to have a toggle just for smartquotes?