### PR TITLE
Add event API with events willparse and parsed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,9 @@ var LinkifyIt    = require('linkify-it');
 var mdurl        = require('mdurl');
 var punycode     = require('punycode');
 
+/* global Symbol */
+var EVENTS = typeof Symbol === 'function' ? Symbol('events') : '__events';
+
 
 var config = {
   'default': require('./presets/default'),
@@ -341,6 +344,8 @@ function MarkdownIt(presetName, options) {
   this.helpers = utils.assign({}, helpers);
 
 
+  this[EVENTS] = {};
+
   this.options = {};
   this.configure(presetName);
 
@@ -520,7 +525,11 @@ MarkdownIt.prototype.parse = function (src, env) {
 
   var state = new this.core.State(src, this, env);
 
+  this.dispatchEvent('willparse', { state: state });
+
   this.core.process(state);
+
+  this.dispatchEvent('parsed', { state: state });
 
   return state.tokens;
 };
@@ -555,9 +564,13 @@ MarkdownIt.prototype.render = function (src, env) {
  **/
 MarkdownIt.prototype.parseInline = function (src, env) {
   var state = new this.core.State(src, this, env);
-
   state.inlineMode = true;
+
+  this.dispatchEvent('willparse', { state: state });
+
   this.core.process(state);
+
+  this.dispatchEvent('parsed', { state: state });
 
   return state.tokens;
 };
@@ -577,5 +590,88 @@ MarkdownIt.prototype.renderInline = function (src, env) {
   return this.renderer.render(this.parseInline(src, env), this.options, env);
 };
 
+
+function Event(name, params) {
+  if (!(this instanceof Event)) {
+    return new Event(name, params);
+  }
+
+  if (typeof params === 'object') {
+    var keys = Object.getOwnPropertyNames(params);
+
+    for (var i = 0; i < keys.length; i++) {
+      this[keys[i]] = params[keys[i]];
+    }
+  }
+
+  this.name = name;
+  this.timeStamp = +(new Date());
+}
+
+
+/**
+ * MarkdownIt.addEventListener(event, fn)
+ * - event (String): event name
+ * - fn (Function): callback
+ *
+ * Registers an event listener. If the function is already subscribed
+ * to this event, does nothing. The callback function will recieve a
+ * single argument - the Event object which contains these properties:
+ * - timestamp: the value of Date.now()
+ * - name: name of the event
+ * - state: (where applicable) the parser's state object
+ *
+ * The available events are:
+ * - willparse
+ * - parsed
+ **/
+MarkdownIt.prototype.addEventListener = function (event, fn) {
+  var callbackArray = this[EVENTS][event] = this[EVENTS][event] || [];
+
+  if (typeof fn !== 'function') {
+    throw new TypeError('Argument 2 must be a function.');
+  }
+
+  if (callbackArray.indexOf(fn) === -1) {
+    callbackArray.push(fn);
+  }
+};
+
+
+/**
+ * MarkdownIt.removeEventListener(event, fn)
+ * - event (String): event name
+ * - fn (Function): callback
+ *
+ * Unsubscribes the callback from the event. If the callback isn't
+ * subscribed, does nothing. See [[MarkdownIt.addEventListener]]
+ * for the list of available events.
+ **/
+MarkdownIt.prototype.removeEventListener = function (event, callback) {
+  var callbackArray = this[EVENTS][event] = this[EVENTS][event] || [];
+  var index = callbackArray.indexOf(callback);
+
+  if (index !== -1) {
+    callbackArray.splice(index, 1);
+  }
+};
+
+
+/**
+ * MarkdownIt.dispatchEvent(event)
+ * - event (String): event name
+ * - params (Object): event parameters
+ *
+ * Call all the functions subscribed to this event.
+ * See [[MarkdownIt.addEventListener]] for the list of available events.
+ **/
+MarkdownIt.prototype.dispatchEvent = function (event, params) {
+  var callbackArray = this[EVENTS][event] = this[EVENTS][event] || [];
+  var e = new Event(event, params);
+
+  for (var i = 0; i < callbackArray.length; i++) {
+    callbackArray[i](e);
+  }
+};
 
 module.exports = MarkdownIt;

--- a/test/misc.js
+++ b/test/misc.js
@@ -154,6 +154,15 @@ describe('API', function () {
     );
   });
 
+  it('event-error', function () {
+    var md = markdownit();
+
+    assert.throws(
+      function () { md.addEventListener('', 42); },
+      /Argument 2 must be a function/
+    );
+  });
+
   it('event-parse', function () {
     var md = markdownit();
     var firedPre = false;


### PR DESCRIPTION
This PR adds API for events. It works the same way it does in DOM (but it doesn't support bubbling/catching). For now, only two events are supported: `willparse` and `parsed`, both events are dispatched when the function `md.parse` (or `md.parseInline`) is called before and after the parsing respectively.

The events are really useful when making an auto-numbering extension, so that you can reset the number before each rendering, or generally for every extension that needs to manage some document-wide data that should be reset with each rendering. Also, they make the `markdown-it` library more transparent to the external code.

New methods:
```typescript
function addEventListener(name: string, fn: (e: Event) => void);
function removeEventListener(name: string, fn: (e: Event) => void);
function dispatchEvent(name: string, props: object);
```

Example usage:
```javascript
md = markdownit();
md.addEventListener('parsed', (e) => updateMyStuff());
md.render('*a*'); // event called
```