### PR TITLE
WIP: Escape special chars

### DIFF
--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -19,9 +19,9 @@ var RARE_RE = /\+-|\.\.|\?\?\?\?|!!!!|,,|--/;
 
 // Workaround for phantomjs - need regex without /g flag,
 // or root check will fail every second time
-var SCOPED_ABBR_TEST_RE = /\((c|tm|r|p)\)/i;
+var SCOPED_ABBR_TEST_RE = /(?:^\((c|tm|r|p)\)|[^\\]\((c|tm|r|p)\))/i;
 
-var SCOPED_ABBR_RE = /\((c|tm|r|p)\)/ig;
+var SCOPED_ABBR_RE = /(?:^\((c|tm|r|p)\)|[^\\]\((c|tm|r|p)\))/ig;
 var SCOPED_ABBR = {
   c: '©',
   r: '®',


### PR DESCRIPTION
Right now, the copyright sign as well as other special char 
specifications like `(tm)`, `(r)` and `(p)` are not escapable.

This patch adds the ability to escape them, simply by checking for a `\` 
(Backslash) in front of the first bracket (`\(tm)` or `\(c)`).

Maybe not the best way, but works :crossed_fingers: