### PR TITLE
Fix language detection with filename

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -43,7 +43,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
       highlighted, i, tmpAttrs, tmpToken;
 
   if (info) {
-    langName = info.split(/\s+/g)[0];
+    langName = info.split(/\s+/g)[0].split(':')[0];
   }
 
   if (options.highlight) {


### PR DESCRIPTION
Enables to detect language of code blocks such as:

\`\`\`[lang]:[filename]
foo 
bar
\`\`\`