### PR TITLE
Encode link text in linkify core rule to avoid homograph attack

### DIFF
--- a/lib/rules_core/linkify.js
+++ b/lib/rules_core/linkify.js
@@ -80,13 +80,14 @@ module.exports = function linkify(state) {
           // Linkifier might send raw hostnames like "example.com", where url
           // starts with domain name. So we prepend http:// in those cases,
           // and remove it afterwards.
-          //
+          // Use "normalizeLink" instead of "normalizeText" to avoid homograph attack.
+          // See https://en.wikipedia.org/wiki/Internationalized_domain_name for details.
           if (!links[ln].schema) {
-            urlText = state.md.normalizeLinkText('http://' + urlText).replace(/^http:\/\//, '');
+            urlText = state.md.normalizeLink('http://' + urlText).replace(/^http:\/\//, '');
           } else if (links[ln].schema === 'mailto:' && !/^mailto:/i.test(urlText)) {
-            urlText = state.md.normalizeLinkText('mailto:' + urlText).replace(/^mailto:/, '');
+            urlText = state.md.normalizeLink('mailto:' + urlText).replace(/^mailto:/, '');
           } else {
-            urlText = state.md.normalizeLinkText(urlText);
+            urlText = state.md.normalizeLink(urlText);
           }
 
           pos = links[ln].index;


### PR DESCRIPTION
As mentioned in https://en.wikipedia.org/wiki/IDN_homograph_attack 

> The internationalized domain name (IDN) homograph attack is a way a malicious party may deceive computer users about what remote system they are communicating with, by exploiting the fact that many different characters look alike (i.e., they are homographs, hence the term for the attack, although technically homoglyph is the more accurate term for different characters that look alike).

Eg.  In the link "http://ebаy.com", "a" looks like Latin "a" but actually is the Cyrillic character. So if we linkify it, text will be "http://ebаy.com" but link will be "http://xn--eby-7cd.com/"

After this change above text `http://ebаy.com` will be rendered as "http://xn--eby-7cd.com/". Such that href and text values of anchor tag will be same.
