### PR TITLE
Don’t recognize U+2028 as a newline character

### DIFF
--- a/lib/rules_core/normalize.js
+++ b/lib/rules_core/normalize.js
@@ -3,7 +3,8 @@
 'use strict';
 
 
-var NEWLINES_RE  = /\r[\n\x85]?|[\u2424\x85]/g;
+// https://spec.commonmark.org/0.29/#line-ending
+var NEWLINES_RE  = /\r\n?|\n/g;
 var NULL_RE      = /\0/g;
 
 

--- a/lib/rules_core/normalize.js
+++ b/lib/rules_core/normalize.js
@@ -3,8 +3,8 @@
 'use strict';
 
 
-var NEWLINES_RE  = /\r[\n\u0085]?|[\u2424\u2028\u0085]/g;
-var NULL_RE      = /\u0000/g;
+var NEWLINES_RE  = /\r[\n\x85]?|[\u2424\x85]/g;
+var NULL_RE      = /\0/g;
 
 
 module.exports = function normalize(state) {


### PR DESCRIPTION
As of https://github.com/tc39/proposal-json-superset (ES2019), U+2028 is allowed in ECMAScript string literals, just like it already was in JSON strings. Splitting on U+2028 breaks the layout of a Markdown file containing a code example:

https://markdown-it.github.io/#md3=%7B%22source%22%3A%22a%5Cn%5Cn%5Cn%60%60%60js%5Cn%2F%2F%20A%20JavaScript%20object%20%28or%20array%2C%20or%20string%29%20representing%20some%20data.%5Cnconst%20data%20%3D%20%7B%5Cn%20%20LineTerminators%3A%20%27%5C%5Cn%5C%5Cr%E2%80%A8%E2%80%A9%27%2C%20%2F%2F%20%27%5C%5Cn%5C%5Cr%5C%5Cu2028%5C%5Cu2029%27%5Cn%7D%3B%5Cn%60%60%60%5Cn%5Cnb%22%2C%22defaults%22%3A%7B%22html%22%3Afalse%2C%22xhtmlOut%22%3Afalse%2C%22breaks%22%3Afalse%2C%22langPrefix%22%3A%22language-%22%2C%22linkify%22%3Atrue%2C%22typographer%22%3Atrue%2C%22_highlight%22%3Atrue%2C%22_strict%22%3Afalse%2C%22_view%22%3A%22html%22%7D%7D

This patch removes U+2028 as a newline character, to align markdown-it’s behavior more closely with the JavaScript string literal grammar.

Thanks for your consideration!