### PR TITLE
Change escapeHtml to escape ' (single quote) and ` (backtick)

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -126,7 +126,9 @@ var HTML_REPLACEMENTS = {
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;',
-  '"': '&quot;'
+  '"': '&quot;',
+  '\'': '&#039;',
+  '`': '&#096;'
 };
 
 function replaceUnsafeChar(ch) {

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -127,8 +127,7 @@ var HTML_REPLACEMENTS = {
   '<': '&lt;',
   '>': '&gt;',
   '"': '&quot;',
-  '\'': '&#039;',
-  '`': '&#096;'
+  '\'': '&#039;'
 };
 
 function replaceUnsafeChar(ch) {


### PR DESCRIPTION
- HTML5 has Single-quoted attribute value syntax. markdown-it shoud be escape ' avoid XSS on the syntax
- IE recognizes backtick as a valid attribute delimiter and it causes mXSS attacks (https://cure53.de/fp170.pdf). This is not essential safeguard but preferred one