### PR TITLE
Add support to use plugins on markdown-it CLI with --plugin parameter

### DIFF
--- a/bin/markdown-it.js
+++ b/bin/markdown-it.js
@@ -47,6 +47,11 @@ cli.addArgument([ '-o', '--output' ], {
   defaultValue: '-'
 });
 
+cli.addArgument([ '--plugin'], {
+  help: 'Plugin',
+  action: 'append'
+});
+
 var options = cli.parseArgs();
 
 
@@ -91,6 +96,13 @@ readFile(options.file, 'utf8', function (err, input) {
     typographer: options.typographer,
     linkify: options.linkify
   });
+
+  if (options.plugin) { 
+    options.plugin.forEach(function(pluginName) {
+      var plugin = require(pluginName);
+      md.use(plugin.default || plugin);
+    }); 
+  }
 
   try {
     output = md.render(input);


### PR DESCRIPTION
With this change, it's possible to add plugins on makrdown-it CLI execution. For exemple, to use the markdown-it-mermaid and markdown-it-footnote plugins, we can just call the markdown-it command with --plugin argument:
```
cat markdown.md | markdown-it --plugin markdown-it-mermaid --plugin markdown-it-footnote
```