### PR TITLE
In demo, fix text in tooltip of “typographer” option

### DIFF
--- a/support/demo_template/index.pug
+++ b/support/demo_template/index.pug
@@ -65,7 +65,7 @@ html
             input#linkify(type='checkbox')
             |  linkify
         .checkbox.not-strict
-          label._tip(title='do typographyc replacements, (c) -> © and so on')
+          label._tip(title='do typographic replacements, (c) → © and so on')
             input#typographer(type='checkbox')
             |  typographer
         .checkbox.not-strict


### PR DESCRIPTION
- Fix spelling of “typographic”
- Use the proper arrow symbol (which is important because using the correct symbols is the point of this option)

The affected page: https://markdown-it.github.io/

The current text on that page, which this commit fixes:

<img width="207" alt="tooltip" src="https://user-images.githubusercontent.com/79168/66076393-b5534b00-e52b-11e9-80c8-33510aea4bd9.png">
