### PR TITLE
No longer replace two periods with ellipsis

### DIFF
--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -63,9 +63,9 @@ function replace_rare(inlineTokens) {
       if (RARE_RE.test(token.content)) {
         token.content = token.content
           .replace(/\+-/g, '±')
-          // .., ..., ....... -> …
+          // ..., ....... -> …
           // but ?..... & !..... -> ?.. & !..
-          .replace(/\.{2,}/g, '…').replace(/([?!])…/g, '$1..')
+          .replace(/\.{3,}/g, '…').replace(/([?!])…/g, '$1..')
           .replace(/([?!]){4,}/g, '$1$1$1').replace(/,{2,}/g, ',')
           // em-dash
           .replace(/(^|[^-])---([^-]|$)/mg, '$1\u2014$2')


### PR DESCRIPTION
Two periods i.e. ".." are often used in representing ranges, e.g. 1..99, means a sequence of numbers 1, 2, 3, 4 all the way to 99 (see F# ranges). The current markdown-it replacements currently clobber the correct sequence with an invalid syntax. 
This change allows the replacement for 3 or more periods, instead of the current 2 or more.