### PR TITLE
Add links to all default rules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ md = require('markdown-it')({
 });
 ```
 
+You can find all rules in sources:
+[parser_core.js](lib/parser_core.js), [parser_block](lib/parser_block.js),
+[parser_inline](lib/parser_inline.js).
+
 
 ## Benchmark
 


### PR DESCRIPTION
There's a function to disable any rules, but all default rules are not described anywhere in docs. This PR adds links to rules in sources to README

relates to #584