### PR TITLE
Add ESM support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ dist/
 node_modules
 support/demo_template/sample.js
 benchmark/extra/
+rollup.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 demo/
 apidoc/
 *.log
+*.mjs

--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
   "repository": "markdown-it/markdown-it",
   "license": "MIT",
   "main": "index.js",
+  "module": "dist/markdown-it.mjs",
   "bin": {
     "markdown-it": "bin/markdown-it.js"
   },
   "scripts": {
+    "build": "rollup -c",
+    "prepare": "npm run build",
     "test": "make test"
   },
   "files": [
     "index.js",
+    "index.mjs",
     "bin/",
     "lib/",
     "dist/"
@@ -56,6 +60,10 @@
     "mocha": "^6.1.4",
     "ndoc": "^5.0.0",
     "pug-cli": "^1.0.0-alpha6",
+    "rollup": "^1.26.3",
+    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-json": "^4.0.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "stylus": "^0.54.5",
     "supertest": "^4.0.2",
     "terser": "^4.1.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,18 @@
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import json from 'rollup-plugin-json';
+
+export default {
+  input: 'index.js',
+  output: {
+    file: 'dist/markdown-it.mjs',
+    format: 'esm'
+  },
+  plugins: [
+    json(),
+    nodeResolve({
+      preferBuiltins: false
+    }),
+    commonjs()
+  ]
+};


### PR DESCRIPTION
Browsers have improved a lot over the past years and it is now possible to do modern web development without requiring any build tools (i.e. buildless) with ESM support.

We are adding ESM support to Prose Mirror and as a requirement, transitive dependencies need to provide an ESM version: 

https://discuss.prosemirror.net/t/prose-mirror-buildless-esm-support/2322

Markdown-it is one of these dependencies.

https://github.com/ProseMirror/prosemirror-markdown

This PR aims to generate an ESM version of the source code before packaging.