### PR TITLE
feat: support boolean attributes

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -2,6 +2,7 @@
 //
 'use strict';
 
+function isNil(v) { return v === null || typeof v === 'undefined'; }
 
 function _class(obj) { return Object.prototype.toString.call(obj); }
 
@@ -299,6 +300,7 @@ exports.lib                 = {};
 exports.lib.mdurl           = require('mdurl');
 exports.lib.ucmicro         = require('uc.micro');
 
+exports.isNil               = isNil;
 exports.assign              = assign;
 exports.isString            = isString;
 exports.has                 = has;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -11,6 +11,7 @@
 var assign          = require('./common/utils').assign;
 var unescapeAll     = require('./common/utils').unescapeAll;
 var escapeHtml      = require('./common/utils').escapeHtml;
+var isNil           = require('./common/utils').isNil;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -174,7 +175,8 @@ Renderer.prototype.renderAttrs = function renderAttrs(token) {
   result = '';
 
   for (i = 0, l = token.attrs.length; i < l; i++) {
-    result += ' ' + escapeHtml(token.attrs[i][0]) + '="' + escapeHtml(token.attrs[i][1]) + '"';
+    var value = token.attrs[i][1];
+    result += ' ' + escapeHtml(token.attrs[i][0]) + (isNil(value) ? '' : '="' + escapeHtml(value) + '"');
   }
 
   return result;

--- a/test/misc.js
+++ b/test/misc.js
@@ -382,6 +382,13 @@ describe('Token attributes', function () {
       md.renderer.render(tokens, md.options),
       '<pre><code class="bar"></code></pre>\n'
     );
+
+    t.attrSet('hidden');
+
+    assert.strictEqual(
+      md.renderer.render(tokens, md.options),
+      '<pre><code class="bar" hidden></code></pre>\n'
+    );
   });
 
   it('.attrGet', function () {


### PR DESCRIPTION
https://github.com/markdown-it/markdown-it/issues/598

Supports:
- `.attrSet('download')` on Token
- `.attrs.push(['download'])` on Token
- `.attrs.push(['download', null])` on Token
- `.attrs.push(['download', undefined])` on Token
