### PR TITLE
refactor: use findIndex

### DIFF
--- a/lib/ruler.js
+++ b/lib/ruler.js
@@ -48,12 +48,9 @@ function Ruler() {
 // Find rule index by name
 //
 Ruler.prototype.__find__ = function (name) {
-  for (var i = 0; i < this.__rules__.length; i++) {
-    if (this.__rules__[i].name === name) {
-      return i;
-    }
-  }
-  return -1;
+  return this.__rules__.findIndex(function (rule) {
+    return rule.name === name;
+  });
 };
 
 

--- a/lib/token.js
+++ b/lib/token.js
@@ -119,16 +119,15 @@ function Token(type, tag, nesting) {
  * Search attribute index by name.
  **/
 Token.prototype.attrIndex = function attrIndex(name) {
-  var attrs, i, len;
+  var attrs;
 
   if (!this.attrs) { return -1; }
 
   attrs = this.attrs;
 
-  for (i = 0, len = attrs.length; i < len; i++) {
-    if (attrs[i][0] === name) { return i; }
-  }
-  return -1;
+  return attrs.findIndex(function (el) {
+    return el[0] === name;
+  });
 };
 
 


### PR DESCRIPTION
Refactor to use [`#findIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex) where appropriate.