### PR TITLE
Fix tables.js for pipes inside backticks

### DIFF
--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -19,8 +19,7 @@ function escapedSplit(str) {
       ch,
       escapes = 0,
       lastPos = 0,
-      backTicked = false,
-      lastBackTick = 0;
+      backTicked = false;
 
   ch  = str.charCodeAt(pos);
 
@@ -30,12 +29,14 @@ function escapedSplit(str) {
         // make \` close code sequence, but not open it;
         // the reason is: `\` is correct code block
         backTicked = false;
-        lastBackTick = pos;
       } else if (escapes % 2 === 0) {
         backTicked = true;
-        lastBackTick = pos;
       }
-    } else if (ch === 0x7c/* | */ && (escapes % 2 === 0) && !backTicked) {
+    } else if (ch === 0x7c/* | */ && (escapes % 2 === 0)
+      && (!backTicked || str.charCodeAt(pos - 1) !== 0x5c/* \ */)) {
+      // If there was an un-closed backtick, close it
+      backTicked = false;
+
       result.push(str.substring(lastPos, pos));
       lastPos = pos + 1;
     }
@@ -48,17 +49,12 @@ function escapedSplit(str) {
 
     pos++;
 
-    // If there was an un-closed backtick, go back to just after
-    // the last backtick, but as if it was a normal character
-    if (pos === max && backTicked) {
-      backTicked = false;
-      pos = lastBackTick + 1;
-    }
-
     ch = str.charCodeAt(pos);
   }
 
   result.push(str.substring(lastPos));
+
+  result = result.map(function (x){ return x.replace('\\|', '|'); });
 
   return result;
 }

--- a/test/fixtures/markdown-it/tables.txt
+++ b/test/fixtures/markdown-it/tables.txt
@@ -319,12 +319,12 @@ Delimiter escaping:
 </table>
 .
 
-Pipes inside backticks don't split cells:
+Pipes inside backticks split cells:
 .
 | Heading 1 | Heading 2
 | --------- | ---------
 | Cell 1 | Cell 2
-| `Cell|3` | Cell 4
+| `Cell 3|Cell 4` | Removed
 .
 <table>
 <thead>
@@ -339,7 +339,61 @@ Pipes inside backticks don't split cells:
 <td>Cell 2</td>
 </tr>
 <tr>
-<td><code>Cell|3</code></td>
+<td>`Cell 3</td>
+<td>Cell 4`</td>
+</tr>
+</tbody>
+</table>
+.
+
+Escaped pipes inside backticks don't split cells:
+.
+| Heading 1 | Heading 2
+| --------- | ---------
+| Cell 1 | Cell 2
+| `Cell 3\|` | Cell 4
+.
+<table>
+<thead>
+<tr>
+<th>Heading 1</th>
+<th>Heading 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td><code>Cell 3|</code></td>
+<td>Cell 4</td>
+</tr>
+</tbody>
+</table>
+.
+
+Escape before escaped Pipes inside backticks don't split cells:
+.
+| Heading 1 | Heading 2
+| --------- | ---------
+| Cell 1 | Cell 2
+| `Cell 3\\|` | Cell 4
+.
+<table>
+<thead>
+<tr>
+<th>Heading 1</th>
+<th>Heading 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td><code>Cell 3\|</code></td>
 <td>Cell 4</td>
 </tr>
 </tbody>


### PR DESCRIPTION
Add test samples and fix wrong test sample

The sample `Pipes inside backticks don't split cells` did not contain the output that github would create from that markdown.

```
 | Heading 1 | Heading 2
 | --------- | ---------
 | Cell 1    | Cell 2
 | `Cell|3`  | Cell 4
```
produces

 | Heading 1 | Heading 2
 | --------- | ---------
 | Cell 1 | Cell 2
 | `Cell|3` | Cell 4

If the current cell is backTicked, the current char is a pipe and the previous char is not an escape, the cell ends.

After adjusting that it is no longer necessary to check if the end has been reached to due an unmatched backtick.