### PR TITLE
fix: remove unused comparison code

### DIFF
--- a/lib/rules_inline/balance_pairs.js
+++ b/lib/rules_inline/balance_pairs.js
@@ -38,9 +38,7 @@ function processDelimiters(state, delimiters) {
 
       if (newMinOpenerIdx === -1) newMinOpenerIdx = openerIdx;
 
-      if (opener.open &&
-          opener.end < 0 &&
-          opener.level === closer.level) {
+      if (opener.open && opener.end < 0) {
 
         isOddMatch = false;
 


### PR DESCRIPTION
Hi. I'm reading the source code of markdown-it. I found these lines seem to be odd.

https://github.com/markdown-it/markdown-it/blob/5789a3fe9693aa3ef6aa882b0f57e0ea61efafc0/lib/rules_inline/balance_pairs.js#L41-L43

`opener` and `closer` are two `delimiter`s, and `level` is not a property of `delimiter`. I ran all tests and `opener.level` and `closer.level` are always `undefined`. So I remove them in this PR.

Please correct me if I missed something. 