### PR TITLE
supporting base64-encoded SVG images

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ var config = {
 //
 
 var BAD_PROTO_RE = /^(vbscript|javascript|file|data):/;
-var GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/;
+var GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp|svg\+xml);/;
 
 function validateLink(url) {
   // url should be normalized at this point, and existing entities are decoded


### PR DESCRIPTION
using data URI with image/svg+xml in <img> is supported by major browsers down to latest MS IE, but markdown-it doesn't detect images properly