### PR TITLE
Add the additional fence attributes to calls to `highlight` so that highlighters can then add them to the <pre> tag

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -47,7 +47,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
   }
 
   if (options.highlight) {
-    highlighted = options.highlight(token.content, langName) || escapeHtml(token.content);
+    highlighted = options.highlight(token.content, langName, token.attrs) || escapeHtml(token.content);
   } else {
     highlighted = escapeHtml(token.content);
   }


### PR DESCRIPTION
I need to be able to pass additional parameters to highlights, such as

    ~~~ javascript {line-numbers=5 highlight=14-17}

These attributes were not being forwarded from the default fence renderer to the `highlight` function.

I've added them in as a third parameter, so the change will be transparent to existing code.


Cheers

Dave