### PR TITLE
Fix linkify example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ var md = require('markdown-it')({
 configure linkify-it, access the linkify instance through `md.linkify`:
 
 ```js
-md.linkify.tlds('.py', false);  // disables .py as top level domain
+md.linkify.set({ fuzzyEmail: false });  // disables converting email to link
 ```
 
 


### PR DESCRIPTION
This pull request updates an example code of Linkify in README. Because it does not work correctly.


# Problem


The example said "disables .py as top level domain" by `md.linkify.tlds('.py', false)`, but it is not correct.


It actually disables all top-level domains, except `..py`. So, with the configuration, linkify doesn't convert `foo.py` to a link, but it also doesn't convert `github.com` and so on. But it converts `foo..py` to a link accidentally. 😂

# Why it happens

The example misunderstood the behavior of linkify-it's `tlds` function.
http://markdown-it.github.io/linkify-it/doc/#LinkifyIt.prototype.tlds

The second argument is "keepOld".

> merge with current list if true (false by default)

So, if it is false, the function replaces the whole of the current list with `['.py']`. It means it only allows `..py` domain.

# Solutoon

I replaced the wrong example with another example that disables converting emails.
I think disabling email conversion is not a rare setting, so it is appropriate.


By the way, I couldn't find an easy way to disable `.py` TLD. I guess we need the following code for this, but it isn't smart for me.

```javascript
md.linkify.tlds(allTopLevelDomainList.filter((tld) => tld !== 'py'), false)
```

So I changed the example from disabling `.py`. 