### PR TITLE
Deep copy `token.attrs` to avoid mutating token stream

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -64,7 +64,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
   // now we prefer to keep things local.
   if (info) {
     i        = token.attrIndex('class');
-    tmpAttrs = token.attrs ? token.attrs.slice() : [];
+    tmpAttrs = token.attrs ? JSON.parse(JSON.stringify(token.attrs)) : [];
 
     if (i < 0) {
       tmpAttrs.push([ 'class', options.langPrefix + langName ]);


### PR DESCRIPTION
Please correct me if I'm wrong but I believe this line https://github.com/markdown-it/markdown-it/blob/be22253b7ccb98ff69f010935a034d601d80ceec/lib/renderer.js#L72 will currently mutate the token stream.

This PR makes a deep copy of `token.attrs` so that mutating `tmpAttrs[i]` will not mutate `token.attrs[i]`