### PR TITLE
Instantiating linkify-it lazily, only if needed

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -39,6 +39,24 @@ function arrayReplaceAt(src, pos, newElements) {
   return [].concat(src.slice(0, pos), newElements, src.slice(pos + 1));
 }
 
+// Sets a property whose initial is computed lazily on an target object
+function defineLazyProperty(target, property, instantiator) {
+  var initied = false;
+  var value;
+  Object.defineProperty(target, property, {
+    get: function () {
+      if (initied) return value;
+      initied = true;
+      value = instantiator();
+      return value;
+    },
+    set: function (newValue) {
+      initied = true;
+      value = newValue;
+    }
+  });
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 function isValidEntityCode(c) {
@@ -300,6 +318,7 @@ exports.lib.mdurl           = require('mdurl');
 exports.lib.ucmicro         = require('uc.micro');
 
 exports.assign              = assign;
+exports.defineLazyProperty  = defineLazyProperty;
 exports.isString            = isString;
 exports.has                 = has;
 exports.unescapeMd          = unescapeMd;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,6 @@ var Renderer     = require('./renderer');
 var ParserCore   = require('./parser_core');
 var ParserBlock  = require('./parser_block');
 var ParserInline = require('./parser_inline');
-var LinkifyIt    = require('linkify-it');
 var mdurl        = require('mdurl');
 var punycode     = require('punycode');
 
@@ -288,7 +287,10 @@ function MarkdownIt(presetName, options) {
    * Used by [linkify](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/linkify.js)
    * rule.
    **/
-  this.linkify = new LinkifyIt();
+  utils.defineLazyProperty(this, 'linkify', function () {
+    var LinkifyIt = require('linkify-it');
+    return new LinkifyIt();
+  });
 
   /**
    * MarkdownIt#validateLink(url) -> Boolean


### PR DESCRIPTION
This PR enables instantiating linkify-it lazily, meaning never if it's disabled.

The advantages are, when linkify-it is disabled: 

- shaving ~4ms (~20%) from startup time (~1.5ms for requiring the module and ~2.5ms for instantiating it), which is relatively marginal but it adds up.
- reducing memory usage by half a megabyte, or more if more than one instantiation of linkify-it is prevented.
  - before:
    ![image](https://user-images.githubusercontent.com/1812093/103464215-de175100-4d29-11eb-8f0a-b81e4dcc7231.png)
  - after
  	![image](https://user-images.githubusercontent.com/1812093/103464217-e8394f80-4d29-11eb-913f-2ec4760c9efc.png)

I know adding more code and making the index file's code uglier is something that the maintainers here want to prevent as much as possible, so I've tried to make the diff as clean as possible. Hopefully this is clean enough.