### PR TITLE
Various performance improvements

### DIFF
--- a/benchmark/benchloop.js
+++ b/benchmark/benchloop.js
@@ -1,0 +1,37 @@
+
+'use strict';
+
+/* IMPORT */
+
+var fs = require ('fs'),
+    path = require ('path'),
+    benchmark = require ('benchloop'),
+    mit = require ('..');
+
+/* HELPERS */
+
+var SAMPLES_PATH = path.join (__dirname, 'samples');
+var md = mit ('commonmark');
+
+/* BENCHMARK */
+
+benchmark.defaultOptions = Object.assign (benchmark.defaultOptions, {
+  iterations: 50,
+  log: 'compact'
+});
+
+fs.readdirSync (SAMPLES_PATH).forEach (function (sample) {
+
+  var samplePath = path.join (SAMPLES_PATH, sample),
+      content = fs.readFileSync (samplePath, 'utf-8');
+
+  benchmark ({
+    name: sample,
+    fn: function () {
+      md.render (content);
+    }
+  });
+
+});
+
+benchmark.summary ();

--- a/benchmark/profile.js
+++ b/benchmark/profile.js
@@ -14,6 +14,8 @@ var md = require('../')({
 // var data = fs.readFileSync(path.join(__dirname, '/samples/lorem1.txt'), 'utf8');
 var data = fs.readFileSync(path.join(__dirname, '../test/fixtures/commonmark/spec.txt'), 'utf8');
 
-for (var i = 0; i < 20; i++) {
+console.time('profile');
+for (var i = 0; i < 200; i++) {
   md.render(data);
 }
+console.timeEnd('profile');

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -13,6 +13,14 @@ function has(object, key) {
   return _hasOwnProperty.call(object, key);
 }
 
+var _repeat = String.prototype.repeat || function (count) {
+  return new Array(count + 1).join (this);
+};
+
+function repeat(str, count) {
+  return _repeat.call (str, count);
+}
+
 // Merge objects
 //
 function assign(obj /*from1, from2, from3, ...*/) {
@@ -237,7 +245,7 @@ function isMdAsciiPunct(ch) {
   }
 }
 
-// Hepler to unify [reference labels].
+// Helper to unify [reference labels].
 //
 function normalizeReference(str) {
   // Trim and collapse whitespace
@@ -302,6 +310,7 @@ exports.lib.ucmicro         = require('uc.micro');
 exports.assign              = assign;
 exports.isString            = isString;
 exports.has                 = has;
+exports.repeat              = repeat;
 exports.unescapeMd          = unescapeMd;
 exports.unescapeAll         = unescapeAll;
 exports.isValidEntityCode   = isValidEntityCode;

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -128,25 +128,38 @@ function unescapeAll(str) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-var HTML_ESCAPE_TEST_RE = /[&<>"]/;
-var HTML_ESCAPE_REPLACE_RE = /[&<>"]/g;
-var HTML_REPLACEMENTS = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;'
-};
+var escapeHtml = (function () {
+  if ( typeof XMLSerializer === 'function' ) {
+    var serializer = new XMLSerializer ();
+    var attr = document.createAttribute ( 'attr' );
+    var re = /[&<>"]/;
+    return function escapeHtml ( str ) {
+      if ( !re.test ( str ) ) return str;
+      attr.value = str;
+      return serializer.serializeToString ( attr );
+    }
+  } else {
+    var HTML_ESCAPE_TEST_RE = /[&<>"]/;
+    var HTML_ESCAPE_REPLACE_RE = /[&<>"]/g;
+    var HTML_REPLACEMENTS = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;'
+    };
 
-function replaceUnsafeChar(ch) {
-  return HTML_REPLACEMENTS[ch];
-}
+    function replaceUnsafeChar(ch) {
+      return HTML_REPLACEMENTS[ch];
+    }
 
-function escapeHtml(str) {
-  if (HTML_ESCAPE_TEST_RE.test(str)) {
-    return str.replace(HTML_ESCAPE_REPLACE_RE, replaceUnsafeChar);
+    return function escapeHtml(str) {
+      if (HTML_ESCAPE_TEST_RE.test(str)) {
+        return str.replace(HTML_ESCAPE_REPLACE_RE, replaceUnsafeChar);
+      }
+      return str;
+    }
   }
-  return str;
-}
+})();
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -44,9 +44,14 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
       highlighted, i, arr, tmpAttrs, tmpToken;
 
   if (info) {
-    arr = info.split(/(\s+)/g);
-    langName = arr[0];
-    langAttrs = arr.slice(2).join('');
+    if (!/\s/.test (info)) {
+      langName = info;
+      langAttrs = '';
+    } else {
+      arr = info.split(/(\s+)/g);
+      langName = arr[0];
+      langAttrs = arr.slice(2).join('');
+    }
   }
 
   if (options.highlight) {
@@ -55,7 +60,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
     highlighted = escapeHtml(token.content);
   }
 
-  if (highlighted.indexOf('<pre') === 0) {
+  if (highlighted.slice(0, 4) === '<pre') {
     return highlighted + '\n';
   }
 
@@ -63,12 +68,12 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
   // May be, one day we will add .deepClone() for token and simplify this part, but
   // now we prefer to keep things local.
   if (info) {
-    i        = token.attrIndex('class');
-    tmpAttrs = token.attrs ? token.attrs.slice() : [];
+    i = token.attrIndex('class');
 
     if (i < 0) {
-      tmpAttrs.push([ 'class', options.langPrefix + langName ]);
+      tmpAttrs = [ [ 'class', options.langPrefix + langName ] ];
     } else {
+      tmpAttrs = token.attrs.slice();
       tmpAttrs[i] = tmpAttrs[i].slice();
       tmpAttrs[i][1] += ' ' + options.langPrefix + langName;
     }
@@ -77,6 +82,12 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
     tmpToken = {
       attrs: tmpAttrs
     };
+
+    if (i < 0) {
+      return  '<pre><code' + slf.renderAttrs(token) + slf.renderAttrs(tmpToken) + '>'
+            + highlighted
+            + '</code></pre>\n';
+    }
 
     return  '<pre><code' + slf.renderAttrs(tmpToken) + '>'
           + highlighted
@@ -293,13 +304,17 @@ Renderer.prototype.renderInline = function (tokens, options, env) {
  * instead of simple escaping.
  **/
 Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
-  var result = '';
+  var type, token,
+      result = '';
 
   for (var i = 0, len = tokens.length; i < len; i++) {
-    if (tokens[i].type === 'text') {
-      result += tokens[i].content;
-    } else if (tokens[i].type === 'image') {
-      result += this.renderInlineAsText(tokens[i].children, options, env);
+    token = tokens[i];
+    type = token.type;
+
+    if (type === 'text') {
+      result += token.content;
+    } else if (type === 'image') {
+      result += this.renderInlineAsText(token.children, options, env);
     }
   }
 
@@ -317,17 +332,18 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
  * this method directly.
  **/
 Renderer.prototype.render = function (tokens, options, env) {
-  var i, len, type,
+  var i, len, type, token,
       result = '',
       rules = this.rules;
 
   for (i = 0, len = tokens.length; i < len; i++) {
-    type = tokens[i].type;
+    token = tokens[i];
+    type = token.type;
 
     if (type === 'inline') {
-      result += this.renderInline(tokens[i].children, options, env);
+      result += this.renderInline(token.children, options, env);
     } else if (typeof rules[type] !== 'undefined') {
-      result += rules[tokens[i].type](tokens, i, options, env, this);
+      result += rules[type](tokens, i, options, env, this);
     } else {
       result += this.renderToken(tokens, i, options, env);
     }

--- a/lib/rules_block/blockquote.js
+++ b/lib/rules_block/blockquote.js
@@ -6,6 +6,9 @@ var isSpace = require('../common/utils').isSpace;
 
 
 module.exports = function blockquote(state, startLine, endLine, silent) {
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
+
   var adjustTab,
       ch,
       i,
@@ -29,9 +32,6 @@ module.exports = function blockquote(state, startLine, endLine, silent) {
       oldLineMax = state.lineMax,
       pos = state.bMarks[startLine] + state.tShift[startLine],
       max = state.eMarks[startLine];
-
-  // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
 
   // check the block quote marker
   if (state.src.charCodeAt(pos++) !== 0x3E/* > */) { return false; }

--- a/lib/rules_block/code.js
+++ b/lib/rules_block/code.js
@@ -4,9 +4,9 @@
 
 
 module.exports = function code(state, startLine, endLine/*, silent*/) {
-  var nextLine, last, token;
-
   if (state.sCount[startLine] - state.blkIndent < 4) { return false; }
+
+  var nextLine, last, token;
 
   last = nextLine = startLine + 1;
 

--- a/lib/rules_block/fence.js
+++ b/lib/rules_block/fence.js
@@ -4,13 +4,13 @@
 
 
 module.exports = function fence(state, startLine, endLine, silent) {
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
+
   var marker, len, params, nextLine, mem, token, markup,
       haveEndMarker = false,
       pos = state.bMarks[startLine] + state.tShift[startLine],
       max = state.eMarks[startLine];
-
-  // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
 
   if (pos + 3 > max) { return false; }
 

--- a/lib/rules_block/heading.js
+++ b/lib/rules_block/heading.js
@@ -6,12 +6,12 @@ var isSpace = require('../common/utils').isSpace;
 
 
 module.exports = function heading(state, startLine, endLine, silent) {
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
+
   var ch, level, tmp, token,
       pos = state.bMarks[startLine] + state.tShift[startLine],
       max = state.eMarks[startLine];
-
-  // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
 
   ch  = state.src.charCodeAt(pos);
 

--- a/lib/rules_block/hr.js
+++ b/lib/rules_block/hr.js
@@ -3,15 +3,16 @@
 'use strict';
 
 var isSpace = require('../common/utils').isSpace;
+var repeat = require('../common/utils').repeat;
 
 
 module.exports = function hr(state, startLine, endLine, silent) {
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
+
   var marker, cnt, ch, token,
       pos = state.bMarks[startLine] + state.tShift[startLine],
       max = state.eMarks[startLine];
-
-  // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
 
   marker = state.src.charCodeAt(pos++);
 
@@ -39,7 +40,7 @@ module.exports = function hr(state, startLine, endLine, silent) {
 
   token        = state.push('hr', 'hr', 0);
   token.map    = [ startLine, state.line ];
-  token.markup = Array(cnt + 1).join(String.fromCharCode(marker));
+  token.markup = repeat (String.fromCharCode(marker), cnt);
 
   return true;
 };

--- a/lib/rules_block/html_block.js
+++ b/lib/rules_block/html_block.js
@@ -21,14 +21,14 @@ var HTML_SEQUENCES = [
 
 
 module.exports = function html_block(state, startLine, endLine, silent) {
-  var i, nextLine, token, lineText,
-      pos = state.bMarks[startLine] + state.tShift[startLine],
-      max = state.eMarks[startLine];
+  if (!state.md.options.html) { return false; }
 
   // if it's indented more than 3 spaces, it should be a code block
   if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
 
-  if (!state.md.options.html) { return false; }
+  var i, nextLine, token, lineText,
+      pos = state.bMarks[startLine] + state.tShift[startLine],
+      max = state.eMarks[startLine];
 
   if (state.src.charCodeAt(pos) !== 0x3C/* < */) { return false; }
 

--- a/lib/rules_block/lheading.js
+++ b/lib/rules_block/lheading.js
@@ -4,12 +4,12 @@
 
 
 module.exports = function lheading(state, startLine, endLine/*, silent*/) {
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
+
   var content, terminate, i, l, token, pos, max, level, marker,
       nextLine = startLine + 1, oldParentType,
       terminatorRules = state.md.block.ruler.getRules('paragraph');
-
-  // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
 
   oldParentType = state.parentType;
   state.parentType = 'paragraph'; // use paragraph to match terminatorRules

--- a/lib/rules_block/list.js
+++ b/lib/rules_block/list.js
@@ -11,7 +11,6 @@ function skipBulletListMarker(state, startLine) {
   var marker, pos, max, ch;
 
   pos = state.bMarks[startLine] + state.tShift[startLine];
-  max = state.eMarks[startLine];
 
   marker = state.src.charCodeAt(pos++);
   // Check bullet
@@ -20,6 +19,8 @@ function skipBulletListMarker(state, startLine) {
       marker !== 0x2B/* + */) {
     return -1;
   }
+
+  max = state.eMarks[startLine];
 
   if (pos < max) {
     ch = state.src.charCodeAt(pos);
@@ -84,13 +85,14 @@ function skipOrderedListMarker(state, startLine) {
 }
 
 function markTightParagraphs(state, idx) {
-  var i, l,
+  var i, l, token,
       level = state.level + 2;
 
   for (i = idx + 2, l = state.tokens.length - 2; i < l; i++) {
-    if (state.tokens[i].level === level && state.tokens[i].type === 'paragraph_open') {
+    token = state.tokens[i];
+    if (token.level === level && token.type === 'paragraph_open') {
       state.tokens[i + 2].hidden = true;
-      state.tokens[i].hidden = true;
+      token.hidden = true;
       i += 2;
     }
   }
@@ -98,6 +100,21 @@ function markTightParagraphs(state, idx) {
 
 
 module.exports = function list(state, startLine, endLine, silent) {
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
+
+  // Special case:
+  //  - item 1
+  //   - item 2
+  //    - item 3
+  //     - item 4
+  //      - this one is a paragraph continuation
+  if (state.listIndent >= 0 &&
+    state.sCount[startLine] - state.listIndent >= 4 &&
+    state.sCount[startLine] < state.blkIndent) {
+    return false;
+  }
+
   var ch,
       contentStart,
       i,
@@ -128,21 +145,6 @@ module.exports = function list(state, startLine, endLine, silent) {
       token,
       isTerminatingParagraph = false,
       tight = true;
-
-  // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
-
-  // Special case:
-  //  - item 1
-  //   - item 2
-  //    - item 3
-  //     - item 4
-  //      - this one is a paragraph continuation
-  if (state.listIndent >= 0 &&
-      state.sCount[startLine] - state.listIndent >= 4 &&
-      state.sCount[startLine] < state.blkIndent) {
-    return false;
-  }
 
   // limit conditions when list can interrupt
   // a paragraph (validation mode only)

--- a/lib/rules_block/reference.js
+++ b/lib/rules_block/reference.js
@@ -6,6 +6,9 @@ var isSpace              = require('../common/utils').isSpace;
 
 
 module.exports = function reference(state, startLine, _endLine, silent) {
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
+
   var ch,
       destEndPos,
       destEndLineNo,
@@ -26,9 +29,6 @@ module.exports = function reference(state, startLine, _endLine, silent) {
       pos = state.bMarks[startLine] + state.tShift[startLine],
       max = state.eMarks[startLine],
       nextLine = startLine + 1;
-
-  // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false; }
 
   if (state.src.charCodeAt(pos) !== 0x5B/* [ */) { return false; }
 

--- a/lib/rules_block/state_block.js
+++ b/lib/rules_block/state_block.js
@@ -4,6 +4,7 @@
 
 var Token = require('../token');
 var isSpace = require('../common/utils').isSpace;
+var repeat = require('../common/utils').repeat;
 
 
 function StateBlock(src, md, env, tokens) {
@@ -173,14 +174,13 @@ StateBlock.prototype.skipCharsBack = function skipCharsBack(pos, code, min) {
 
 // cut lines range from source.
 StateBlock.prototype.getLines = function getLines(begin, end, indent, keepLastLF) {
-  var i, lineIndent, ch, first, last, queue, lineStart,
+  var i, lineIndent, ch, first, last, lineStart,
+      lines = '',
       line = begin;
 
   if (begin >= end) {
-    return '';
+    return lines;
   }
-
-  queue = new Array(end - begin);
 
   for (i = 0; line < end; line++, i++) {
     lineIndent = 0;
@@ -215,13 +215,13 @@ StateBlock.prototype.getLines = function getLines(begin, end, indent, keepLastLF
     if (lineIndent > indent) {
       // partially expanding tabs in code blocks, e.g '\t\tfoobar'
       // with indent=2 becomes '  \tfoobar'
-      queue[i] = new Array(lineIndent - indent + 1).join(' ') + this.src.slice(first, last);
+      lines += repeat (' ', lineIndent - indent) + this.src.slice(first, last);
     } else {
-      queue[i] = this.src.slice(first, last);
+      lines += this.src.slice(first, last);
     }
   }
 
-  return queue.join('');
+  return lines;
 };
 
 // re-export Token class to use in block rules

--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -50,19 +50,19 @@ function escapedSplit(str) {
 
 
 module.exports = function table(state, startLine, endLine, silent) {
-  var ch, lineText, pos, i, l, nextLine, columns, columnCount, token,
-      aligns, t, tableLines, tbodyLines, oldParentType, terminate,
-      terminatorRules;
-
   // should have at least two lines
   if (startLine + 2 > endLine) { return false; }
 
-  nextLine = startLine + 1;
+  var nextLine = startLine + 1;
 
   if (state.sCount[nextLine] < state.blkIndent) { return false; }
 
   // if it's indented more than 3 spaces, it should be a code block
   if (state.sCount[nextLine] - state.blkIndent >= 4) { return false; }
+
+  var ch, lineText, pos, i, l, columns, columnCount, token,
+      aligns, t, tableLines, tbodyLines, oldParentType, terminate,
+      terminatorRules;
 
   // first character of the second line should be '|', '-', ':',
   // and no other characters are allowed but spaces;

--- a/lib/rules_core/linkify.js
+++ b/lib/rules_core/linkify.js
@@ -17,12 +17,12 @@ function isLinkClose(str) {
 
 
 module.exports = function linkify(state) {
+  if (!state.md.options.linkify) { return; }
+
   var i, j, l, tokens, token, currentToken, nodes, ln, text, pos, lastPos,
       level, htmlLinkLevel, url, fullUrl, urlText,
       blockTokens = state.tokens,
       links;
-
-  if (!state.md.options.linkify) { return; }
 
   for (j = 0, l = blockTokens.length; j < l; j++) {
     if (blockTokens[j].type !== 'inline' ||

--- a/lib/rules_core/normalize.js
+++ b/lib/rules_core/normalize.js
@@ -4,18 +4,21 @@
 
 
 // https://spec.commonmark.org/0.29/#line-ending
-var NEWLINES_RE  = /\r\n?|\n/g;
-var NULL_RE      = /\0/g;
+var CRLF_RE = /\r\n?/g;
 
 
 module.exports = function normalize(state) {
-  var str;
+  var src = state.src;
 
-  // Normalize newlines
-  str = state.src.replace(NEWLINES_RE, '\n');
+  // Normalize CRLF newlines
+  src = src.replace(CRLF_RE, '\n');
 
   // Replace NULL characters
-  str = str.replace(NULL_RE, '\uFFFD');
+  for (var i = 0, l = src.length; i < l; i++) {
+    if (!src.charCodeAt(i)) {
+      src = src.slice (0, i) + '\uFFFD' + src.slice (i + 1);
+    }
+  }
 
-  state.src = str;
+  state.src = src;
 };

--- a/lib/rules_core/smartquotes.js
+++ b/lib/rules_core/smartquotes.js
@@ -26,7 +26,7 @@ function process_inlines(tokens, state) {
   for (i = 0; i < tokens.length; i++) {
     token = tokens[i];
 
-    thisLevel = tokens[i].level;
+    thisLevel = token.level;
 
     for (j = stack.length - 1; j >= 0; j--) {
       if (stack[j].level <= thisLevel) { break; }

--- a/lib/rules_inline/autolink.js
+++ b/lib/rules_inline/autolink.js
@@ -9,10 +9,10 @@ var AUTOLINK_RE = /^([a-zA-Z][a-zA-Z0-9+.\-]{1,31}):([^<>\x00-\x20]*)$/;
 
 
 module.exports = function autolink(state, silent) {
+  if (state.src.charCodeAt(state.pos) !== 0x3C/* < */) { return false; }
+
   var url, fullUrl, token, ch, start, max,
       pos = state.pos;
-
-  if (state.src.charCodeAt(pos) !== 0x3C/* < */) { return false; }
 
   start = state.pos;
   max = state.posMax;

--- a/lib/rules_inline/backticks.js
+++ b/lib/rules_inline/backticks.js
@@ -4,11 +4,12 @@
 
 
 module.exports = function backtick(state, silent) {
-  var start, max, marker, token, matchStart, matchEnd, openerLength, closerLength,
-      pos = state.pos,
-      ch = state.src.charCodeAt(pos);
+  var ch = state.src.charCodeAt(state.pos);
 
   if (ch !== 0x60/* ` */) { return false; }
+
+  var start, max, marker, token, matchStart, matchEnd, openerLength, closerLength,
+      pos = state.pos;
 
   start = pos;
   pos++;

--- a/lib/rules_inline/emphasis.js
+++ b/lib/rules_inline/emphasis.js
@@ -6,13 +6,13 @@
 // Insert each marker as a separate text token, and add it to delimiter list
 //
 module.exports.tokenize = function emphasis(state, silent) {
-  var i, scanned, token,
-      start = state.pos,
-      marker = state.src.charCodeAt(start);
-
   if (silent) { return false; }
 
+  var marker = state.src.charCodeAt(state.pos);
+
   if (marker !== 0x5F /* _ */ && marker !== 0x2A /* * */) { return false; }
+
+  var i, scanned, token;
 
   scanned = state.scanDelims(state.pos, marker === 0x2A);
 

--- a/lib/rules_inline/entity.js
+++ b/lib/rules_inline/entity.js
@@ -13,9 +13,9 @@ var NAMED_RE   = /^&([a-z][a-z0-9]{1,31});/i;
 
 
 module.exports = function entity(state, silent) {
-  var ch, code, match, pos = state.pos, max = state.posMax;
+  if (state.src.charCodeAt(state.pos) !== 0x26/* & */) { return false; }
 
-  if (state.src.charCodeAt(pos) !== 0x26/* & */) { return false; }
+  var ch, code, match, pos = state.pos, max = state.posMax;
 
   if (pos + 1 < max) {
     ch = state.src.charCodeAt(pos + 1);

--- a/lib/rules_inline/escape.js
+++ b/lib/rules_inline/escape.js
@@ -13,9 +13,9 @@ for (var i = 0; i < 256; i++) { ESCAPED.push(0); }
 
 
 module.exports = function escape(state, silent) {
-  var ch, pos = state.pos, max = state.posMax;
+  if (state.src.charCodeAt(state.pos) !== 0x5C/* \ */) { return false; }
 
-  if (state.src.charCodeAt(pos) !== 0x5C/* \ */) { return false; }
+  var ch, pos = state.pos, max = state.posMax;
 
   pos++;
 

--- a/lib/rules_inline/html_inline.js
+++ b/lib/rules_inline/html_inline.js
@@ -14,17 +14,17 @@ function isLetter(ch) {
 
 
 module.exports = function html_inline(state, silent) {
-  var ch, match, max, token,
-      pos = state.pos;
-
   if (!state.md.options.html) { return false; }
 
   // Check start
-  max = state.posMax;
-  if (state.src.charCodeAt(pos) !== 0x3C/* < */ ||
-      pos + 2 >= max) {
+  var max = state.posMax;
+  if (state.src.charCodeAt(state.pos) !== 0x3C/* < */ ||
+      state.pos + 2 >= max) {
     return false;
   }
+
+  var ch, match, token,
+      pos = state.pos;
 
   // Quick fail on second char
   ch = state.src.charCodeAt(pos + 1);

--- a/lib/rules_inline/image.js
+++ b/lib/rules_inline/image.js
@@ -7,6 +7,9 @@ var isSpace              = require('../common/utils').isSpace;
 
 
 module.exports = function image(state, silent) {
+  if (state.src.charCodeAt(state.pos) !== 0x21/* ! */) { return false; }
+  if (state.src.charCodeAt(state.pos + 1) !== 0x5B/* [ */) { return false; }
+
   var attrs,
       code,
       content,
@@ -23,9 +26,6 @@ module.exports = function image(state, silent) {
       href = '',
       oldPos = state.pos,
       max = state.posMax;
-
-  if (state.src.charCodeAt(state.pos) !== 0x21/* ! */) { return false; }
-  if (state.src.charCodeAt(state.pos + 1) !== 0x5B/* [ */) { return false; }
 
   labelStart = state.pos + 2;
   labelEnd = state.md.helpers.parseLinkLabel(state, state.pos + 1, false);

--- a/lib/rules_inline/link.js
+++ b/lib/rules_inline/link.js
@@ -7,6 +7,8 @@ var isSpace              = require('../common/utils').isSpace;
 
 
 module.exports = function link(state, silent) {
+  if (state.src.charCodeAt(state.pos) !== 0x5B/* [ */) { return false; }
+
   var attrs,
       code,
       label,
@@ -22,8 +24,6 @@ module.exports = function link(state, silent) {
       max = state.posMax,
       start = state.pos,
       parseReference = true;
-
-  if (state.src.charCodeAt(state.pos) !== 0x5B/* [ */) { return false; }
 
   labelStart = state.pos + 1;
   labelEnd = state.md.helpers.parseLinkLabel(state, state.pos, true);

--- a/lib/rules_inline/newline.js
+++ b/lib/rules_inline/newline.js
@@ -6,11 +6,13 @@ var isSpace = require('../common/utils').isSpace;
 
 
 module.exports = function newline(state, silent) {
-  var pmax, max, pos = state.pos;
+  if (state.src.charCodeAt(state.pos) !== 0x0A/* \n */) { return false; }
 
-  if (state.src.charCodeAt(pos) !== 0x0A/* \n */) { return false; }
+  var pmax, max,
+      pending = state.pending,
+      pos = state.pos;
 
-  pmax = state.pending.length - 1;
+  pmax = pending.length - 1;
   max = state.posMax;
 
   // '  \n' -> hardbreak
@@ -18,12 +20,12 @@ module.exports = function newline(state, silent) {
   // Pending string is stored in concat mode, indexed lookups will cause
   // convertion to flat mode.
   if (!silent) {
-    if (pmax >= 0 && state.pending.charCodeAt(pmax) === 0x20) {
-      if (pmax >= 1 && state.pending.charCodeAt(pmax - 1) === 0x20) {
-        state.pending = state.pending.replace(/ +$/, '');
+    if (pmax >= 0 && pending.charCodeAt(pmax) === 0x20) {
+      if (pmax >= 1 && pending.charCodeAt(pmax - 1) === 0x20) {
+        state.pending = pending.replace(/ +$/, '');
         state.push('hardbreak', 'br', 0);
       } else {
-        state.pending = state.pending.slice(0, -1);
+        state.pending = pending.slice(0, -1);
         state.push('softbreak', 'br', 0);
       }
 

--- a/lib/rules_inline/strikethrough.js
+++ b/lib/rules_inline/strikethrough.js
@@ -6,13 +6,13 @@
 // Insert each marker as a separate text token, and add it to delimiter list
 //
 module.exports.tokenize = function strikethrough(state, silent) {
-  var i, scanned, token, len, ch,
-      start = state.pos,
-      marker = state.src.charCodeAt(start);
-
   if (silent) { return false; }
 
+  var marker = state.src.charCodeAt(state.pos);
+
   if (marker !== 0x7E/* ~ */) { return false; }
+
+  var i, scanned, token, len, ch;
 
   scanned = state.scanDelims(state.pos, true);
   len = scanned.length;

--- a/lib/rules_inline/text_collapse.js
+++ b/lib/rules_inline/text_collapse.js
@@ -10,26 +10,27 @@
 
 
 module.exports = function text_collapse(state) {
-  var curr, last,
+  var curr, last, token,
       level = 0,
       tokens = state.tokens,
-      max = state.tokens.length;
+      max = tokens.length;
 
   for (curr = last = 0; curr < max; curr++) {
+    token = tokens[curr];
     // re-calculate levels after emphasis/strikethrough turns some text nodes
     // into opening/closing tags
-    if (tokens[curr].nesting < 0) level--; // closing tag
-    tokens[curr].level = level;
-    if (tokens[curr].nesting > 0) level++; // opening tag
+    if (token.nesting < 0) level--; // closing tag
+    token.level = level;
+    if (token.nesting > 0) level++; // opening tag
 
-    if (tokens[curr].type === 'text' &&
+    if (token.type === 'text' &&
         curr + 1 < max &&
         tokens[curr + 1].type === 'text') {
 
       // collapse two adjacent text nodes
-      tokens[curr + 1].content = tokens[curr].content + tokens[curr + 1].content;
+      tokens[curr + 1].content = token.content + tokens[curr + 1].content;
     } else {
-      if (curr !== last) { tokens[last] = tokens[curr]; }
+      if (curr !== last) { tokens[last] = token; }
 
       last++;
     }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@rollup/plugin-node-resolve": "^10.0.0",
     "ansi": "^0.3.0",
     "autoprefixer-stylus": "^1.0.0",
+    "benchloop": "^1.3.2",
     "benchmark": "~2.1.0",
     "chai": "^4.2.0",
     "coveralls": "^3.0.4",


### PR DESCRIPTION
I tried to optimize the library a bit, there wasn't much that could have been easily optimized away but there was something.

I don't expect this PR to get merged in its entirety, or at all, I'm mostly writing this as a brain dump, but there are actually a few very minor changes I found that make some signficant difference, maybe those should be ported over here, your choice.

##### Summary

Overall the profile script now runs in ~23% less time.

All tests conducted under Node v15.5.0, older versions might give considerably different results.

<details>
  <summary>10 sample runs (Before)</summary>

```
profile: 2.516s
profile: 2.537s
profile: 2.695s
profile: 2.658s
profile: 2.508s
profile: 2.537s
profile: 2.572s
profile: 2.526s
profile: 2.536s
profile: 2.587s

avg: 2.567s
improvement: 0%
```

</details>

<details>
  <summary>10 sample runs (After)</summary>

```
profile: 1.965s
profile: 1.940s
profile: 1.924s
profile: 1.920s
profile: 2.085s
profile: 2.063s
profile: 1.929s
profile: 1.948s
profile: 1.935s
profile: 1.979s

avg: 1.969s
improvement: 23.3%
```

</details>

##### Optimizations

- Significant:
  - `lib/rules_core/normalize.js`
    - optimizing this single rule gave by far the largest performance gains of the lot. 
    - turns out that replacing "\n" with "\n" is a significant performance burden, so just removing "|\n" from the regex, a 3 characters diff, would be a significant performance improvement.
    - because of a [bug](https://bugs.chromium.org/p/v8/issues/detail?id=10737&sort=-stars&q=&can=4) in v8 looking for "\0" in strings that don't contain only ASCII character is a significant performance cliff, just iterating over the entire thing and performing the change manually turned out to be significantly faster.
      - by the way I don't see the point of replacing "\0" in JS so this replacement should probably be removed entirely, breaking away slightly from CM as this requirement by the spec has only downsides in JS really. 
- Minor:
  - `lib/common/utils.js`
    - Using `String.prototype.repeat` whenever possible, that's 10x faster than the previous implementation and more memory efficient.
  - `lib/renderer.js`
    - `fence`
      - most of the times the "info" string doesn't contain any spaces, so I added a fast path for that that doesn't do so much wasteful stuff.
      - asking for the index of `<pre` is not actually what we need, we don't want to scan the entire thing, we only care about how it starts, so it now only considers the first 4 characters of the string.
      - when adding the "class" attribute pretty much always there's no need to clone the current attributes array at all, so I added a more optimized path for that common case.
  - `lib/rules_block/state_block.js`
    - apparently creating an intermediary array is slower than just progressively joining those lines (~90ms vs ~15ms).
- Very Minor:
  - some unnecessary property accesses have been removed.
  - some exit conditions in rules have been moved slightly up in the functions, ensuring those functions exit as quickly as possible when those exit conditions are met.
    - this was a pretty noisy change with not that much to gain from really.

##### Other Changes

- `benchmark/benchloop.js`
  - I added another profiling script, one that's not so tied to how the CM spec is written and that gives some output quickly.
- `benchmark/profile.js`
  - 10x more iterations are executed, giving more time to v8 to optimize things.
  - A number is outputted, otherwise this file is not very useful IMO, timing the entire script is not what we want as that would count disk reads etc.

##### Potential Future Optimizations

- Near future
  - something like 30% of the time spent is now spent html-escaping strings, maybe that could be optimized somehow, everything I tried so far didn't work. Maybe the set of escaped characters could be shrinked and that would improve things.
  - some functions are not monomorphic, like numbers are being sent to be html-escaped too. It's difficult to optimize on this without any types at all, perhaps if there's any plan to add types to markdown-it there's something that could be done here.
  - the shape of tokens ("hidden class" as v8 calls it) changes too at runtime, I'm not sure how much there is to gain from never changing it, but it may be worth trying something in that regard.
  - overall I just don't think that there are some non-high-effort optimizations that would make the library twice as fast from what it is now.
- Far future
  - at the end of the day dealing with strings seems to be the bottleneck here, we just don't have enough control over them to make manipulating them faster. Perhaps the entire Markdown string should be transformed to bytes, those bytes/numbers should be manipulated directly, and then they could be transformed back to strings at the end of the process.
  - if the compiler worked mostly just with numbers, and didn't use regexes, perhaps it could be ported to WASM with some reasonable amount of effort.
  - if the compiler worked from WASM there might be something interesting that would be possible to do there with SIMD instructions, there seem to be at least a Markdown [compiler](https://github.com/raphlinus/pulldown-cmark) that uses them.

##### End

I'd probably just port over the modified "normalize" rule to get most of the performance benefits with ~none of the noise.

Sorry for the long write.