### PR TITLE
Configurable typographer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,8 +153,8 @@ function normalizeLinkText(url) {
  * - __typographer__  - `false`. Set `true` to enable all [language-neutral
  *   replacement](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/replacements.js) +
  *   quotes beautification (smartquotes). Or use an Object to enable
- *   specific replacements, like `{rare: true, ipSymbols:
- *   true, quotes: true, dashes: true}`.
+ *   specific replacements, like `{rare: true, ipSymbols: true, quotes: true,
+ *   dashes: true}`.
  * - __quotes__ - `“”‘’`, String or Array. Double + single quotes replacement
  *   pairs, when typographer enabled and smartquotes on. For example, you can
  *   use `'«»„“'` for Russian, `'„“‚‘'` for German, and

--- a/lib/index.js
+++ b/lib/index.js
@@ -154,7 +154,7 @@ function normalizeLinkText(url) {
  *   replacement](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/replacements.js) +
  *   quotes beautification (smartquotes). Or use an Object to enable
  *   specific replacements, like `{rare: true, intellectualProperty:
- *   true, quotes: true}`.
+ *   true, quotes: true, dashes: true}`.
  * - __quotes__ - `“”‘’`, String or Array. Double + single quotes replacement
  *   pairs, when typographer enabled and smartquotes on. For example, you can
  *   use `'«»„“'` for Russian, `'„“‚‘'` for German, and

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,7 +153,7 @@ function normalizeLinkText(url) {
  * - __typographer__  - `false`. Set `true` to enable all [language-neutral
  *   replacement](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/replacements.js) +
  *   quotes beautification (smartquotes). Or use an Object to enable
- *   specific replacements, like `{rare: true, intellectualProperty:
+ *   specific replacements, like `{rare: true, ipSymbols:
  *   true, quotes: true, dashes: true}`.
  * - __quotes__ - `“”‘’`, String or Array. Double + single quotes replacement
  *   pairs, when typographer enabled and smartquotes on. For example, you can

--- a/lib/index.js
+++ b/lib/index.js
@@ -150,9 +150,11 @@ function normalizeLinkText(url) {
  * - __langPrefix__ - `language-`. CSS language class prefix for fenced blocks.
  *   Can be useful for external highlighters.
  * - __linkify__ - `false`. Set `true` to autoconvert URL-like text to links.
- * - __typographer__  - `false`. Set `true` to enable [some language-neutral
+ * - __typographer__  - `false`. Set `true` to enable all [language-neutral
  *   replacement](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/replacements.js) +
- *   quotes beautification (smartquotes).
+ *   quotes beautification (smartquotes). Or use an Object to enable
+ *   specific replacements, like `{rare: true, intellectualProperty:
+ *   true, quotes: true}`.
  * - __quotes__ - `“”‘’`, String or Array. Double + single quotes replacement
  *   pairs, when typographer enabled and smartquotes on. For example, you can
  *   use `'«»„“'` for Russian, `'„“‚‘'` for German, and

--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -85,21 +85,25 @@ function replace_rare(inlineTokens) {
   }
 }
 
-
 module.exports = function replace(state) {
   var blkIdx;
+  var typographerOption = state.md.options.typographer;
 
-  if (!state.md.options.typographer) { return; }
+  if (!typographerOption) { return; }
+
+  var optionIsObject = typeof typographerOption === 'object';
+  var replaceRare = !optionIsObject || typographerOption.rare;
+  var replaceIP = !optionIsObject || typographerOption.intellectualProperty;
 
   for (blkIdx = state.tokens.length - 1; blkIdx >= 0; blkIdx--) {
 
     if (state.tokens[blkIdx].type !== 'inline') { continue; }
 
-    if (SCOPED_ABBR_TEST_RE.test(state.tokens[blkIdx].content)) {
+    if (replaceIP && SCOPED_ABBR_TEST_RE.test(state.tokens[blkIdx].content)) {
       replace_scoped(state.tokens[blkIdx].children);
     }
 
-    if (RARE_RE.test(state.tokens[blkIdx].content)) {
+    if (replaceRare && RARE_RE.test(state.tokens[blkIdx].content)) {
       replace_rare(state.tokens[blkIdx].children);
     }
 

--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -107,7 +107,7 @@ module.exports = function replace(state) {
 
   var optionIsObject = typeof typographerOption === 'object';
   var replaceRare = !optionIsObject || typographerOption.rare;
-  var replaceIP = !optionIsObject || typographerOption.intellectualProperty;
+  var replaceIP = !optionIsObject || typographerOption.ipSymbols;
   var replaceDashes = !optionIsObject || typographerOption.dashes;
 
   for (blkIdx = state.tokens.length - 1; blkIdx >= 0; blkIdx--) {

--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -55,20 +55,15 @@ function replace_scoped(inlineTokens) {
   }
 }
 
-function replace_rare(inlineTokens) {
+function replace_helper(inlineTokens, re, replacer) {
   var i, token, inside_autolink = 0;
 
   for (i = inlineTokens.length - 1; i >= 0; i--) {
     token = inlineTokens[i];
 
     if (token.type === 'text' && !inside_autolink) {
-      if (RARE_RE.test(token.content)) {
-        token.content = token.content
-          .replace(/\+-/g, '±')
-          // .., ..., ....... -> …
-          // but ?..... & !..... -> ?.. & !..
-          .replace(/\.{2,}/g, '…').replace(/([?!])…/g, '$1..')
-          .replace(/([?!]){4,}/g, '$1$1$1').replace(/,{2,}/g, ',');
+      if (re.test(token.content)) {
+        token.content = replacer(token.content);
       }
     }
 
@@ -82,31 +77,26 @@ function replace_rare(inlineTokens) {
   }
 }
 
+function replace_rare(inlineTokens) {
+  replace_helper(inlineTokens, RARE_RE, function (content) {
+    return content
+      .replace(/\+-/g, '±')
+      // .., ..., ....... -> …
+      // but ?..... & !..... -> ?.. & !..
+      .replace(/\.{2,}/g, '…').replace(/([?!])…/g, '$1..')
+      .replace(/([?!]){4,}/g, '$1$1$1').replace(/,{2,}/g, ',');
+  });
+}
+
 function replace_dashes(inlineTokens) {
-  var i, token, inside_autolink = 0;
-
-  for (i = inlineTokens.length - 1; i >= 0; i--) {
-    token = inlineTokens[i];
-
-    if (token.type === 'text' && !inside_autolink) {
-      if (DASHES_RE.test(token.content)) {
-        token.content = token.content
-          // em-dash
-          .replace(/(^|[^-])---(?=[^-]|$)/mg, '$1\u2014')
-          // en-dash
-          .replace(/(^|\s)--(?=\s|$)/mg, '$1\u2013')
-          .replace(/(^|[^-\s])--(?=[^-\s]|$)/mg, '$1\u2013');
-      }
-    }
-
-    if (token.type === 'link_open' && token.info === 'auto') {
-      inside_autolink--;
-    }
-
-    if (token.type === 'link_close' && token.info === 'auto') {
-      inside_autolink++;
-    }
-  }
+  replace_helper(inlineTokens, DASHES_RE, function (content) {
+    return content
+      // em-dash
+      .replace(/(^|[^-])---(?=[^-]|$)/mg, '$1\u2014')
+      // en-dash
+      .replace(/(^|\s)--(?=\s|$)/mg, '$1\u2013')
+      .replace(/(^|[^-\s])--(?=[^-\s]|$)/mg, '$1\u2013');
+  });
 }
 
 module.exports = function replace(state) {

--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -15,7 +15,9 @@
 // - fractionals 1/2, 1/4, 3/4 -> ½, ¼, ¾
 // - miltiplication 2 x 4 -> 2 × 4
 
-var RARE_RE = /\+-|\.\.|\?\?\?\?|!!!!|,,|--/;
+var RARE_RE = /\+-|\.\.|\?\?\?\?|!!!!|,,/;
+
+var DASHES_RE = /--/;
 
 // Workaround for phantomjs - need regex without /g flag,
 // or root check will fail every second time
@@ -66,7 +68,29 @@ function replace_rare(inlineTokens) {
           // .., ..., ....... -> …
           // but ?..... & !..... -> ?.. & !..
           .replace(/\.{2,}/g, '…').replace(/([?!])…/g, '$1..')
-          .replace(/([?!]){4,}/g, '$1$1$1').replace(/,{2,}/g, ',')
+          .replace(/([?!]){4,}/g, '$1$1$1').replace(/,{2,}/g, ',');
+      }
+    }
+
+    if (token.type === 'link_open' && token.info === 'auto') {
+      inside_autolink--;
+    }
+
+    if (token.type === 'link_close' && token.info === 'auto') {
+      inside_autolink++;
+    }
+  }
+}
+
+function replace_dashes(inlineTokens) {
+  var i, token, inside_autolink = 0;
+
+  for (i = inlineTokens.length - 1; i >= 0; i--) {
+    token = inlineTokens[i];
+
+    if (token.type === 'text' && !inside_autolink) {
+      if (DASHES_RE.test(token.content)) {
+        token.content = token.content
           // em-dash
           .replace(/(^|[^-])---(?=[^-]|$)/mg, '$1\u2014')
           // en-dash
@@ -94,6 +118,7 @@ module.exports = function replace(state) {
   var optionIsObject = typeof typographerOption === 'object';
   var replaceRare = !optionIsObject || typographerOption.rare;
   var replaceIP = !optionIsObject || typographerOption.intellectualProperty;
+  var replaceDashes = !optionIsObject || typographerOption.dashes;
 
   for (blkIdx = state.tokens.length - 1; blkIdx >= 0; blkIdx--) {
 
@@ -101,6 +126,10 @@ module.exports = function replace(state) {
 
     if (replaceIP && SCOPED_ABBR_TEST_RE.test(state.tokens[blkIdx].content)) {
       replace_scoped(state.tokens[blkIdx].children);
+    }
+
+    if (replaceDashes && DASHES_RE.test(state.tokens[blkIdx].content)) {
+      replace_dashes(state.tokens[blkIdx].children);
     }
 
     if (replaceRare && RARE_RE.test(state.tokens[blkIdx].content)) {

--- a/lib/rules_core/smartquotes.js
+++ b/lib/rules_core/smartquotes.js
@@ -187,7 +187,11 @@ module.exports = function smartquotes(state) {
   /*eslint max-depth:0*/
   var blkIdx;
 
-  if (!state.md.options.typographer) { return; }
+  var typographerOption = state.md.options.typographer;
+  if (!typographerOption) { return; }
+
+  var optionIsObject = typeof typographerOption === 'object';
+  if (optionIsObject && !typographerOption.quotes) { return; }
 
   for (blkIdx = state.tokens.length - 1; blkIdx >= 0; blkIdx--) {
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -367,7 +367,7 @@ describe('typographer switches', function () {
         dashes: true,
         quotes: true,
         rare: true,
-        intellectualProperty: false
+        ipSymbols: false
       }
     });
     assert.strictEqual(
@@ -382,7 +382,7 @@ describe('typographer switches', function () {
         dashes: true,
         quotes: false,
         rare: true,
-        intellectualProperty: true
+        ipSymbols: true
       }
     });
     assert.strictEqual(
@@ -397,7 +397,7 @@ describe('typographer switches', function () {
         dashes: true,
         quotes: true,
         rare: false,
-        intellectualProperty: true
+        ipSymbols: true
       }
     });
     assert.strictEqual(
@@ -412,7 +412,7 @@ describe('typographer switches', function () {
         dashes: false,
         quotes: true,
         rare: true,
-        intellectualProperty: true
+        ipSymbols: true
       }
     });
     assert.strictEqual(

--- a/test/misc.js
+++ b/test/misc.js
@@ -359,6 +359,53 @@ describe('smartquotes', function () {
 });
 
 
+describe('typographer switches', function () {
+
+  it('Should support disabling IP symbols', function () {
+    var md = markdownit({
+      typographer: {
+        quotes: true,
+        rare: true,
+        intellectualProperty: false
+      }
+    });
+    assert.strictEqual(
+      md.render('(P) means "phonogram"!!!!!!'),
+      '<p>(P) means “phonogram”!!!</p>\n'
+    );
+  });
+
+  it('Should support disabling quote replacements', function () {
+    var md = markdownit({
+      typographer: {
+        quotes: false,
+        rare: true,
+        intellectualProperty: true
+      }
+    });
+    assert.strictEqual(
+      md.render('Should\'ve registered that (c)!!!!!!'),
+      '<p>Should\'ve registered that ©!!!</p>\n'
+    );
+  });
+
+  it('Should support disabling rare replacements', function () {
+    var md = markdownit({
+      typographer: {
+        quotes: true,
+        rare: false,
+        intellectualProperty: true
+      }
+    });
+    assert.strictEqual(
+      md.render('Definitely should\'ve registered that (c)!!!!!!'),
+      '<p>Definitely should’ve registered that ©!!!!!!</p>\n'
+    );
+  });
+
+});
+
+
 describe('Token attributes', function () {
   it('.attrJoin', function () {
     var md = markdownit();

--- a/test/misc.js
+++ b/test/misc.js
@@ -364,6 +364,7 @@ describe('typographer switches', function () {
   it('Should support disabling IP symbols', function () {
     var md = markdownit({
       typographer: {
+        dashes: true,
         quotes: true,
         rare: true,
         intellectualProperty: false
@@ -378,6 +379,7 @@ describe('typographer switches', function () {
   it('Should support disabling quote replacements', function () {
     var md = markdownit({
       typographer: {
+        dashes: true,
         quotes: false,
         rare: true,
         intellectualProperty: true
@@ -392,6 +394,7 @@ describe('typographer switches', function () {
   it('Should support disabling rare replacements', function () {
     var md = markdownit({
       typographer: {
+        dashes: true,
         quotes: true,
         rare: false,
         intellectualProperty: true
@@ -400,6 +403,21 @@ describe('typographer switches', function () {
     assert.strictEqual(
       md.render('Definitely should\'ve registered that (c)!!!!!!'),
       '<p>Definitely should’ve registered that ©!!!!!!</p>\n'
+    );
+  });
+
+  it('Should support disabling dash replacements', function () {
+    var md = markdownit({
+      typographer: {
+        dashes: false,
+        quotes: true,
+        rare: true,
+        intellectualProperty: true
+      }
+    });
+    assert.strictEqual(
+      md.render('(R) --- it\'s like (c) for trademarks!!!!!!!'),
+      '<p>® --- it’s like © for trademarks!!!</p>\n'
     );
   });
 


### PR DESCRIPTION
This pull request extends the `typographer` configuration option to allow users to provide an Object, rather than just`true`, with flags to toggle specific categories of replacements on and off. I have made rather granular commits, in case that aids review, but welcome a squash-merge.

This work comes out of discussions about the Discourse Internet discussion forum project, where we've found that some replacements, especially `(c)` &rarr; &copy;, trip up users, especially when copying lower-alpha enumerated lists:

```markdown
Common fruits include (a) apples, (b) bananas, (c) copyrights, and (d) dates.
```

Rendered:

> Common fruits include (a) apples, (b) bananas, &copy; copyrights, and (d) dates.

Desired:

> Common fruits include (a) apples, (b) bananas, (c) copyrights, and (d) dates.

These kinds of lists are especially common in outlines, statutes, contracts, and policies.

At the same time, other replacements, like typographers' quotes and dashes, work well for users, and don't cause frustrating problems quoting existing texts in Markdown.

I have no strong feelings about the format of the of Object option. I'm also open to revising this PR to allow a function, rather than a configuration option for the existing replacer configuration. I regret I'm not familiar enough with the stability guarantees around the parser APIs that would expose to know offhand whether that would be more complex or less so.

This PR is my original work, not within the scope of any IP arrangement with the company behind Discourse or any other. I'm happy to license it under the same MIT terms under which the module is currently licensed, waiving any right to have a copyright notice with my name included in copies and substantial portions.