### PR TITLE
Fix table/list parsing ambiguity

### DIFF
--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -52,7 +52,7 @@ function escapedSplit(str) {
 module.exports = function table(state, startLine, endLine, silent) {
   var ch, lineText, pos, i, l, nextLine, columns, columnCount, token,
       aligns, t, tableLines, tbodyLines, oldParentType, terminate,
-      terminatorRules;
+      terminatorRules, firstCh, secondCh;
 
   // should have at least two lines
   if (startLine + 2 > endLine) { return false; }
@@ -71,8 +71,22 @@ module.exports = function table(state, startLine, endLine, silent) {
   pos = state.bMarks[nextLine] + state.tShift[nextLine];
   if (pos >= state.eMarks[nextLine]) { return false; }
 
-  ch = state.src.charCodeAt(pos++);
-  if (ch !== 0x7C/* | */ && ch !== 0x2D/* - */ && ch !== 0x3A/* : */) { return false; }
+  firstCh = state.src.charCodeAt(pos++);
+
+  if (pos >= state.eMarks[nextLine]) { return false; }
+  secondCh = state.src.charCodeAt(pos++);
+
+  // if first character is '-', then second character must not be a space
+  // (due to parsing ambiguity with list)
+  if (firstCh === 0x2D/* - */) {
+    if (secondCh !== 0x7C/* | */ && secondCh !== 0x2D/* - */ && secondCh !== 0x3A/* : */) { return false; }
+  } else if (firstCh === 0x7C/* | */ || firstCh === 0x3A/* : */) {
+    if (secondCh !== 0x7C/* | */ && secondCh !== 0x2D/* - */ && secondCh !== 0x3A/* : */ && !isSpace(secondCh)) {
+      return false;
+    }
+  } else {
+    return false;
+  }
 
   while (pos < state.eMarks[nextLine]) {
     ch = state.src.charCodeAt(pos);

--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -72,21 +72,18 @@ module.exports = function table(state, startLine, endLine, silent) {
   if (pos >= state.eMarks[nextLine]) { return false; }
 
   firstCh = state.src.charCodeAt(pos++);
+  if (firstCh !== 0x7C/* | */ && firstCh !== 0x2D/* - */ && firstCh !== 0x3A/* : */) { return false; }
 
   if (pos >= state.eMarks[nextLine]) { return false; }
+
   secondCh = state.src.charCodeAt(pos++);
+  if (secondCh !== 0x7C/* | */ && secondCh !== 0x2D/* - */ && secondCh !== 0x3A/* : */ && !isSpace(secondCh)) {
+    return false;
+  }
 
   // if first character is '-', then second character must not be a space
   // (due to parsing ambiguity with list)
-  if (firstCh === 0x2D/* - */) {
-    if (secondCh !== 0x7C/* | */ && secondCh !== 0x2D/* - */ && secondCh !== 0x3A/* : */) { return false; }
-  } else if (firstCh === 0x7C/* | */ || firstCh === 0x3A/* : */) {
-    if (secondCh !== 0x7C/* | */ && secondCh !== 0x2D/* - */ && secondCh !== 0x3A/* : */ && !isSpace(secondCh)) {
-      return false;
-    }
-  } else {
-    return false;
-  }
+  if (firstCh === 0x2D/* - */ && isSpace(secondCh)) { return false; }
 
   while (pos < state.eMarks[nextLine]) {
     ch = state.src.charCodeAt(pos);

--- a/test/fixtures/markdown-it/tables.txt
+++ b/test/fixtures/markdown-it/tables.txt
@@ -793,3 +793,16 @@ GFM 4.10 Tables (extension), Example 205
 </thead>
 </table>
 .
+
+A list takes precedence in case of ambiguity
+.
+a | b
+- | -
+1 | 2
+.
+<p>a | b</p>
+<ul>
+<li>| -
+1 | 2</li>
+</ul>
+.


### PR DESCRIPTION
Fix parsing of
```markdown
a | b
- | -
1 | 2
```

Markdown-it parses it as a table, but it should not be one, because there is a list on the second line that intercepts the table.

The GFM spec says:
> A leading and trailing pipe is also recommended for clarity of reading, and if there’s otherwise parsing ambiguity.

Also GitHub's own parser parses this as a list, not a table.