### PR TITLE
Switch default html option to false (safer) for CommonMark

### DIFF
--- a/lib/presets/commonmark.js
+++ b/lib/presets/commonmark.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   options: {
-    html:         true,         // Enable HTML tags in source
+    html:         false,        // Enable HTML tags in source
     xhtmlOut:     true,         // Use '/' to close single tags (<br />)
     breaks:       false,        // Convert '\n' in paragraphs into <br>
     langPrefix:   'language-',  // CSS language prefix for fenced blocks

--- a/test/commonmark.js
+++ b/test/commonmark.js
@@ -33,3 +33,11 @@ describe('CommonMark', function () {
 
   generate(p.join(__dirname, 'fixtures/commonmark/good.txt'), md);
 });
+
+describe('CommonMark defaults', function () {
+  var md = require('../')('commonmark');
+
+  it('defaults to the safe html false options', function () {
+    assert.strictEqual(md.render('<script>alert();</script>'), '<p>&lt;script&gt;alert();&lt;/script&gt;</p>\n');
+  });
+});


### PR DESCRIPTION
Allowing html tags by default for the CommonMark preset is unsafe. Definitely got me surprised when I wrote an injection test to actually be vulnerable by default. Explicitly passing false works. This also lines it up with the README. 

Example below, I'm working downstream in the ruby port:

```
irb(main):003:0> MarkdownIt::Parser.new(:commonmark).render('<script>alert();</alert>')
=> "<script>alert();</alert>"
irb(main):004:0> MarkdownIt::Parser.new(:commonmark, { html: false }).render('<script>alert();</alert>')
=> "<p>&lt;script&gt;alert();&lt;/alert&gt;</p>\n"
```