### PR TITLE
Allowlisting data:image/svg+xml

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ var config = {
 //
 
 var BAD_PROTO_RE = /^(vbscript|javascript|file|data):/;
-var GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/;
+var GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|svg\+xml|webp);/;
 
 function validateLink(url) {
   // url should be normalized at this point, and existing entities are decoded

--- a/test/misc.js
+++ b/test/misc.js
@@ -314,7 +314,9 @@ describe('Links validation', function () {
   it('default should skip blocklisted protocols', function () {
     var md = markdownit();
 
-    assert.strictEqual(md.render('![test](data:image/x-something;base64,)'), '<p>![test](data:image/x-something;base64,)</p>\n');
+    // Note: MIME type of SVG is "image/svg+xml", but not "image/svg".
+    assert.strictEqual(md.render('![test](data:image/svg;base64,)'), '<p>![test](data:image/svg;base64,)</p>\n');
+    assert.strictEqual(md.render('![test](data:image/vnd-something;base64,)'), '<p>![test](data:image/vnd-something;base64,)</p>\n');
     assert.strictEqual(md.render('![test](data:text/javascript;base64,)'), '<p>![test](data:text/javascript;base64,)</p>\n');
     assert.strictEqual(md.render('![test](vbscript:alert())'), '<p>![test](vbscript:alert())</p>\n');
     assert.strictEqual(md.render('![test](javascript:alert())'), '<p>![test](javascript:alert())</p>\n');

--- a/test/misc.js
+++ b/test/misc.js
@@ -294,6 +294,33 @@ describe('Links validation', function () {
     assert.strictEqual(md.render('![test](http://example.com)'), '<p>![test](http://example.com)</p>\n');
   });
 
+  it('default should allow common data:image/*', function () {
+    var md = markdownit();
+
+    assert.strictEqual(md.render('![test](data:image/gif;base64,)'), '<p><img src="data:image/gif;base64," alt="test"></p>\n');
+    assert.strictEqual(md.render('![test](data:image/png;base64,)'), '<p><img src="data:image/png;base64," alt="test"></p>\n');
+    assert.strictEqual(md.render('![test](data:image/jpeg;base64,)'), '<p><img src="data:image/jpeg;base64," alt="test"></p>\n');
+    assert.strictEqual(md.render('![test](data:image/svg+xml;base64,)'), '<p><img src="data:image/svg+xml;base64," alt="test"></p>\n');
+    assert.strictEqual(md.render('![test](data:image/webp;base64,)'), '<p><img src="data:image/webp;base64," alt="test"></p>\n');
+  });
+
+  it('default should allow tel: and map:', function () {
+    var md = markdownit();
+
+    assert.strictEqual(md.render('[Call me](tel:1234567)'), '<p><a href="tel:1234567">Call me</a></p>\n');
+    assert.strictEqual(md.render('[Track me](map:12.3,45.6)'), '<p><a href="map:12.3,45.6">Track me</a></p>\n');
+  });
+
+  it('default should skip blocklisted protocols', function () {
+    var md = markdownit();
+
+    assert.strictEqual(md.render('![test](data:image/x-something;base64,)'), '<p>![test](data:image/x-something;base64,)</p>\n');
+    assert.strictEqual(md.render('![test](data:text/javascript;base64,)'), '<p>![test](data:text/javascript;base64,)</p>\n');
+    assert.strictEqual(md.render('![test](vbscript:alert())'), '<p>![test](vbscript:alert())</p>\n');
+    assert.strictEqual(md.render('![test](javascript:alert())'), '<p>![test](javascript:alert())</p>\n');
+    assert.strictEqual(md.render('![test](file:/root.txt)'), '<p>![test](file:/root.txt)</p>\n');
+  });
+
 });
 
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -297,11 +297,30 @@ describe('Links validation', function () {
   it('default should allow common data:image/*', function () {
     var md = markdownit();
 
-    assert.strictEqual(md.render('![test](data:image/gif;base64,)'), '<p><img src="data:image/gif;base64," alt="test"></p>\n');
-    assert.strictEqual(md.render('![test](data:image/png;base64,)'), '<p><img src="data:image/png;base64," alt="test"></p>\n');
-    assert.strictEqual(md.render('![test](data:image/jpeg;base64,)'), '<p><img src="data:image/jpeg;base64," alt="test"></p>\n');
-    assert.strictEqual(md.render('![test](data:image/svg+xml;base64,)'), '<p><img src="data:image/svg+xml;base64," alt="test"></p>\n');
-    assert.strictEqual(md.render('![test](data:image/webp;base64,)'), '<p><img src="data:image/webp;base64," alt="test"></p>\n');
+    assert.strictEqual(
+      md.render('![test](data:image/gif;base64,)'),
+      '<p><img src="data:image/gif;base64," alt="test"></p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](data:image/png;base64,)'),
+      '<p><img src="data:image/png;base64," alt="test"></p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](data:image/jpeg;base64,)'),
+      '<p><img src="data:image/jpeg;base64," alt="test"></p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](data:image/svg+xml;base64,)'),
+      '<p><img src="data:image/svg+xml;base64," alt="test"></p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](data:image/webp;base64,)'),
+      '<p><img src="data:image/webp;base64," alt="test"></p>\n'
+    );
   });
 
   it('default should allow tel: and map:', function () {
@@ -315,12 +334,35 @@ describe('Links validation', function () {
     var md = markdownit();
 
     // Note: MIME type of SVG is "image/svg+xml", but not "image/svg".
-    assert.strictEqual(md.render('![test](data:image/svg;base64,)'), '<p>![test](data:image/svg;base64,)</p>\n');
-    assert.strictEqual(md.render('![test](data:image/vnd-something;base64,)'), '<p>![test](data:image/vnd-something;base64,)</p>\n');
-    assert.strictEqual(md.render('![test](data:text/javascript;base64,)'), '<p>![test](data:text/javascript;base64,)</p>\n');
-    assert.strictEqual(md.render('![test](vbscript:alert())'), '<p>![test](vbscript:alert())</p>\n');
-    assert.strictEqual(md.render('![test](javascript:alert())'), '<p>![test](javascript:alert())</p>\n');
-    assert.strictEqual(md.render('![test](file:/root.txt)'), '<p>![test](file:/root.txt)</p>\n');
+    assert.strictEqual(
+      md.render('![test](data:image/svg;base64,)'),
+      '<p>![test](data:image/svg;base64,)</p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](data:image/vnd-something;base64,)'),
+      '<p>![test](data:image/vnd-something;base64,)</p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](data:text/javascript;base64,)'),
+      '<p>![test](data:text/javascript;base64,)</p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](vbscript:alert())'),
+      '<p>![test](vbscript:alert())</p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](javascript:alert())'),
+      '<p>![test](javascript:alert())</p>\n'
+    );
+
+    assert.strictEqual(
+      md.render('![test](file:/root.txt)'),
+      '<p>![test](file:/root.txt)</p>\n'
+    );
   });
 
 });


### PR DESCRIPTION
Today, `image/gif`, `image/jpeg`, `image/png`, `image/webp` are allowed by [the default `validateLink`](https://github.com/markdown-it/markdown-it/blob/master/lib/index.js#L33).

As [all browsers (IE 9+) now support SVG](https://caniuse.com/?search=svg), to push vector graphics and hi-res display, we should consider enabling SVG by default.

This pull request is to add `data:image/svg+xml` to the allowlist, enabling SVG in images, such as: `![Logo](data:image/svg+xml;base64,...)`. Also added tests to verify how the default link validator should work.

Mozilla has a great list of image types supported in browsers, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img.

IANA official list of image types can be found at https://www.iana.org/assignments/media-types/media-types.xhtml#image. Note some modern formats such as [HEIF are not supported yet](https://caniuse.com/?search=heic).

Please let me know if you want to include more, such as [Animated PNG](https://caniuse.com/?search=apng), [AVIF](https://caniuse.com/?search=avif), BMP, ICO, and TIFF. Based on browsers support, I think APNG is next logical move to allowlist, but document author maybe unlikely to put it under data URI as the file could be huge.

Thanks.