### PR TITLE
Fix newline not rendered in image alt attribute

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -300,6 +300,8 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
       result += tokens[i].content;
     } else if (tokens[i].type === 'image') {
       result += this.renderInlineAsText(tokens[i].children, options, env);
+    } else if (tokens[i].type === 'softbreak') {
+      result += '\n';
     }
   }
 

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -653,3 +653,12 @@ Issue #772. Header rule should not interfere with html tags.
 ==
 </pre>
 .
+
+Newline in image description
+.
+There is a newline in this image ![here
+it is](https://github.com/executablebooks/)
+.
+<p>There is a newline in this image <img src="https://github.com/executablebooks/" alt="here
+it is"></p>
+.


### PR DESCRIPTION
Newlines in image description should be rendered in `img` "alt" attribute. This is in line with how https://spec.commonmark.org/dingus/ renders it.