### PR TITLE
Update highlight.js examples to new, preferred, calling convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ var md = require('markdown-it')({
   highlight: function (str, lang) {
     if (lang && hljs.getLanguage(lang)) {
       try {
-        return hljs.highlight(lang, str).value;
+        return hljs.highlight(str, { language: lang).value;
       } catch (__) {}
     }
 
@@ -172,7 +172,7 @@ var md = require('markdown-it')({
     if (lang && hljs.getLanguage(lang)) {
       try {
         return '<pre class="hljs"><code>' +
-               hljs.highlight(lang, str, true).value +
+               hljs.highlight(str, { language: lang, ignoreIllegals: true).value +
                '</code></pre>';
       } catch (__) {}
     }


### PR DESCRIPTION
See https://github.com/highlightjs/highlight.js/issues/2277

This prevents the message "Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated. Deprecated as of 10.7.0. Please use highlight(code, options) instead. https://github.com/highlightjs/highlight.js/issues/2277" from appearing on the console which then appeared in my website as I simple wrote "node index.js > blah.html"!