### PR TITLE
fix: [rules:table] Missing `map` property

### DIFF
--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -151,6 +151,7 @@ module.exports = function table(state, startLine, endLine, silent) {
 
   for (i = 0; i < columns.length; i++) {
     token          = state.push('th_open', 'th', 1);
+    token.map      = [ startLine, startLine ];
     if (aligns[i]) {
       token.attrs  = [ [ 'style', 'text-align:' + aligns[i] ] ];
     }
@@ -158,6 +159,7 @@ module.exports = function table(state, startLine, endLine, silent) {
     token          = state.push('inline', '', 0);
     token.content  = columns[i].trim();
     token.children = [];
+    token.map      = [ startLine, startLine ];
 
     token          = state.push('th_close', 'th', -1);
   }
@@ -194,6 +196,7 @@ module.exports = function table(state, startLine, endLine, silent) {
 
     for (i = 0; i < columnCount; i++) {
       token          = state.push('td_open', 'td', 1);
+      token.map      = [ nextLine, nextLine ];
       if (aligns[i]) {
         token.attrs  = [ [ 'style', 'text-align:' + aligns[i] ] ];
       }
@@ -201,6 +204,7 @@ module.exports = function table(state, startLine, endLine, silent) {
       token          = state.push('inline', '', 0);
       token.content  = columns[i] ? columns[i].trim() : '';
       token.children = [];
+      token.map      = [ nextLine, nextLine ];
 
       token          = state.push('td_close', 'td', -1);
     }


### PR DESCRIPTION
Hello!
Thanks a lot to the team for building this project and maintaining it!

This PR fixes the following:
The `map` property of some tokens from the table rule are not set and thus are defaulted to `null`.
