### PR TITLE
Always suffix indented code block with a newline

### DIFF
--- a/lib/rules_block/code.js
+++ b/lib/rules_block/code.js
@@ -27,7 +27,7 @@ module.exports = function code(state, startLine, endLine/*, silent*/) {
   state.line = last;
 
   token         = state.push('code_block', 'code', 0);
-  token.content = state.getLines(startLine, last, 4 + state.blkIndent, true);
+  token.content = state.getLines(startLine, last, 4 + state.blkIndent, false) + '\n';
   token.map     = [ startLine, state.line ];
 
   return true;

--- a/test/misc.js
+++ b/test/misc.js
@@ -182,6 +182,9 @@ describe('Misc', function () {
 
     assert.strictEqual(md.render('123'), '<p>123</p>\n');
     assert.strictEqual(md.render('123\n'), '<p>123</p>\n');
+
+    assert.strictEqual(md.render('    codeblock'), '<pre><code>codeblock\n</code></pre>\n');
+    assert.strictEqual(md.render('    codeblock\n'), '<pre><code>codeblock\n</code></pre>\n');
   });
 
   it('Should quickly exit on empty string', function () {


### PR DESCRIPTION
Currently
```markdown
    codeblock\n
```
(where `\n` represents a trailing newline) renders differently to
```markdown
    codeblock
```
(no trailing newline).

The former renders to
```html
<pre><code>codeblock
</code></pre>
```
and the latter to
```html
<pre><code>codeblock</code></pre>
```

This PR makes the two examples render to the same HTML by always adding a trailing newline to code block content.

The spec is not overly clear about this corner case, but this PR makes
- the behavior in line with how the reference implementation parses and renders https://spec.commonmark.org/dingus/?text=%20%20%20%20codeblock
- makes it so that any indented code block can be reformatted as code fence (useful for markdown formatters)