### PR TITLE
typo fix

### DIFF
--- a/dist/markdown-it.js
+++ b/dist/markdown-it.js
@@ -3252,7 +3252,7 @@
   };
   /**
 	 * Renderer.renderInline(tokens, options, env) -> String
-	 * - tokens (Array): list on block tokens to renter
+	 * - tokens (Array): list on block tokens to render
 	 * - options (Object): params of parser instance
 	 * - env (Object): additional data from parsed input (references, for example)
 	 *
@@ -3271,7 +3271,7 @@
   };
   /** internal
 	 * Renderer.renderInlineAsText(tokens, options, env) -> String
-	 * - tokens (Array): list on block tokens to renter
+	 * - tokens (Array): list on block tokens to render
 	 * - options (Object): params of parser instance
 	 * - env (Object): additional data from parsed input (references, for example)
 	 *
@@ -3293,7 +3293,7 @@
   };
   /**
 	 * Renderer.render(tokens, options, env) -> String
-	 * - tokens (Array): list on block tokens to renter
+	 * - tokens (Array): list on block tokens to render
 	 * - options (Object): params of parser instance
 	 * - env (Object): additional data from parsed input (references, for example)
 	 *

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -257,7 +257,7 @@ Renderer.prototype.renderToken = function renderToken(tokens, idx, options) {
 
 /**
  * Renderer.renderInline(tokens, options, env) -> String
- * - tokens (Array): list on block tokens to renter
+ * - tokens (Array): list on block tokens to render
  * - options (Object): params of parser instance
  * - env (Object): additional data from parsed input (references, for example)
  *
@@ -284,7 +284,7 @@ Renderer.prototype.renderInline = function (tokens, options, env) {
 
 /** internal
  * Renderer.renderInlineAsText(tokens, options, env) -> String
- * - tokens (Array): list on block tokens to renter
+ * - tokens (Array): list on block tokens to render
  * - options (Object): params of parser instance
  * - env (Object): additional data from parsed input (references, for example)
  *
@@ -311,7 +311,7 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
 
 /**
  * Renderer.render(tokens, options, env) -> String
- * - tokens (Array): list on block tokens to renter
+ * - tokens (Array): list on block tokens to render
  * - options (Object): params of parser instance
  * - env (Object): additional data from parsed input (references, for example)
  *


### PR DESCRIPTION
renames `renter` to `render`