### PR TITLE
Fix spelling error in question Github Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!--
 
-Note, we have some time constrains, but we always try to help developers, who write plugins. So:
+Note, we have some time constraints, but we always try to help developers, who write plugins. So:
 
 - Please, avoid generic programming questions.
 - Avoid questions about markdown. Use CommonMark resources for that https://commonmark.org/.


### PR DESCRIPTION
The question template pops text into every new issue and so this spelling error has high exposure. This is a minor change, but when I saw it I noticed the error and I thought it would be nice to fix.