### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -9,7 +9,7 @@ function getLine(state, line) {
   var pos = state.bMarks[line] + state.tShift[line],
       max = state.eMarks[line];
 
-  return state.src.substr(pos, max - pos);
+  return state.src.slice(pos, max);
 }
 
 function escapedSplit(str) {

--- a/lib/rules_core/smartquotes.js
+++ b/lib/rules_core/smartquotes.js
@@ -13,7 +13,7 @@ var APOSTROPHE = '\u2019'; /* ’ */
 
 
 function replaceAt(str, index, ch) {
-  return str.substr(0, index) + ch + str.substr(index + 1);
+  return str.slice(0, index) + ch + str.slice(index + 1);
 }
 
 function process_inlines(tokens, state) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.