### PR TITLE
Support ES Module output in npm package. #862

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,17 @@
   "license": "MIT",
   "main": "index.js",
   "module": "dist/esm/markdown-it.mjs",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/markdown-it.mjs",
+      "require": "./index.js"
+    },
+    "./*": {
+      "require": "./*",
+      "import": "./*"
+    }
+  },
   "bin": {
     "markdown-it": "bin/markdown-it.js"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "main": "index.js",
   "module": "dist/esm/markdown-it.mjs",
-  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/esm/markdown-it.mjs",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   "repository": "markdown-it/markdown-it",
   "license": "MIT",
   "main": "index.js",
+  "module": "dist/esm/markdown-it.mjs",
   "bin": {
     "markdown-it": "bin/markdown-it.js"
   },
   "scripts": {
+    "build": "rollup -c support/rollup.config.js",
     "lint": "eslint .",
     "test": "npm run lint && nyc mocha && node support/specsplit.js",
     "coverage": "npm run test && nyc report --reporter html",

--- a/support/rollup.config.js
+++ b/support/rollup.config.js
@@ -5,6 +5,28 @@ import nodePolyfills from 'rollup-plugin-node-polyfills';
 import pkg from '../package.json';
 import { terser } from 'rollup-plugin-terser';
 
+const unminifiedPlugins = [
+  // Here terser is used only to force ascii output
+  terser({
+    mangle: false,
+    compress: false,
+    format: {
+      comments: 'all',
+      beautify: true,
+      ascii_only: true,
+      indent_level: 2
+    }
+  })
+];
+
+const minifiedPlugins = [
+  terser({
+    format: {
+      ascii_only: true,
+    }
+  })
+];
+
 export default {
   input: 'index.js',
   output: [
@@ -12,31 +34,25 @@ export default {
       file: 'dist/markdown-it.js',
       format: 'umd',
       name: 'markdownit',
-      plugins: [
-        // Here terser is used only to force ascii output
-        terser({
-          mangle: false,
-          compress: false,
-          format: {
-            comments: 'all',
-            beautify: true,
-            ascii_only: true,
-            indent_level: 2
-          }
-        })
-      ]
+      plugins: unminifiedPlugins,
     },
     {
       file: 'dist/markdown-it.min.js',
       format: 'umd',
       name: 'markdownit',
-      plugins: [
-        terser({
-          format: {
-            ascii_only: true,
-          }
-        })
-      ]
+      plugins: minifiedPlugins,
+    },
+    {
+      file: 'dist/esm/markdown-it.mjs',
+      format: 'es',
+      name: 'markdownit',
+      plugins: unminifiedPlugins,
+    },
+    {
+      file: 'dist/esm/markdown-it.min.mjs',
+      format: 'es',
+      name: 'markdownit',
+      plugins: minifiedPlugins,
     }
   ],
   plugins: [


### PR DESCRIPTION
Adds ES Module (ESM) output in the Rollup config (in addition to the existing UMD output), and adds a helpful `npm run build` script. Fixes #862

Per the `CONTRIBUTING.md` file, I am not including the ESM build here, but I can easily add that if you would like.

Example Angular component using the ESM build (add to package.json as a file-path dependency) which does not have the warning about optimization bailouts:

```typescript
import { Component, OnInit } from '@angular/core';
import MarkdownIt from 'markdown-it';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html',
  styleUrls: ['./app.component.scss']
})
export class AppComponent implements OnInit {
  title = 'markdown-it-ng-demo';
  text: string = "";

  ngOnInit(): void {
    const md = new MarkdownIt();
    console.log(md);
    this.text = md.render("# Hi!");
    console.log(this.text);
  }
}
```

Template HTML:
```html
<div [innerHTML]="text"></div>
```