### PR TITLE
fix(rules/fence): trim info trailling whitespaces

### DIFF
--- a/lib/rules_block/fence.js
+++ b/lib/rules_block/fence.js
@@ -89,7 +89,7 @@ module.exports = function fence(state, startLine, endLine, silent) {
   state.line = nextLine + (haveEndMarker ? 1 : 0);
 
   token         = state.push('fence', 'code', 0);
-  token.info    = params;
+  token.info    = params.trim();
   token.content = state.getLines(startLine + 1, nextLine, len, true);
   token.markup  = markup;
   token.map     = [ startLine, state.line ];


### PR DESCRIPTION
trim trailling whitespaces from info field of the fence token