### PR TITLE
Add source line number attribute in order to allow sync scrolls

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -219,6 +219,19 @@ Renderer.prototype.renderToken = function renderToken(tokens, idx, options) {
   // Add token name, e.g. `<img`
   result += (token.nesting === -1 ? '</' : '<') + token.tag;
 
+  // Add source line number attribute in order to allow sync scrolls
+  // Idea extracted from (https://markdown-it.github.io/index.js)
+  if (options.lineNumber) {
+    if (token.map && token.level === 0) {
+      var attr = [ 'data-line', token.map[0] ];
+      if (token.attrs) {
+        token.attrs.push(attr);
+      } else {
+        token.attrs = [ attr ];
+      }
+    }
+  }
+
   // Encode attributes, e.g. `<img src="foo"`
   result += this.renderAttrs(token);
 


### PR DESCRIPTION
Hi! I'm coding a markdown editor for a newsletter page, and i have the challenge doing a sync scroll in my react component library

Then, i'm based of the actual markdown-it demo, and I get noticed of the data attribute "data-line" in the markdown render, that's very useful for sync scrolls

I research the source code, the demo has code for put the data attribute in each token, so I assume the library has support for that. But when i checked the API i didn't see that (sorry if that functionality actually exists in the package)

The purpose of this pull request is add the functionality of the demo in the actual package with a flag (lineNumber)

Thanks for check the PR, cheers  