### PR TITLE
chore: Update entities dependency

### DIFF
--- a/lib/common/entities.js
+++ b/lib/common/entities.js
@@ -1,6 +1,0 @@
-// HTML5 entities map: { name -> utf16string }
-//
-'use strict';
-
-/*eslint quotes:0*/
-module.exports = require('entities/lib/maps/entities.json');

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -77,13 +77,14 @@ var UNESCAPE_ALL_RE = new RegExp(UNESCAPE_MD_RE.source + '|' + ENTITY_RE.source,
 
 var DIGITAL_ENTITY_TEST_RE = /^#((?:x[a-f0-9]{1,8}|[0-9]{1,8}))$/i;
 
-var entities = require('./entities');
+var decodeHTML = require('entities').decodeHTML;
 
 function replaceEntityPattern(match, name) {
-  var code;
+  var decoded, code;
 
-  if (has(entities, name)) {
-    return entities[name];
+  decoded = decodeHTML(match);
+  if (decoded !== match) {
+    return decoded;
   }
 
   if (name.charCodeAt(0) === 0x23/* # */ && DIGITAL_ENTITY_TEST_RE.test(name)) {

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -82,11 +82,6 @@ var decodeHTML = require('entities').decodeHTML;
 function replaceEntityPattern(match, name) {
   var decoded, code;
 
-  decoded = decodeHTML(match);
-  if (decoded !== match) {
-    return decoded;
-  }
-
   if (name.charCodeAt(0) === 0x23/* # */ && DIGITAL_ENTITY_TEST_RE.test(name)) {
     code = name[1].toLowerCase() === 'x' ?
       parseInt(name.slice(2), 16) : parseInt(name.slice(1), 10);
@@ -94,6 +89,13 @@ function replaceEntityPattern(match, name) {
     if (isValidEntityCode(code)) {
       return fromCodePoint(code);
     }
+
+    return match;
+  }
+
+  decoded = decodeHTML(match);
+  if (decoded !== match) {
+    return decoded;
   }
 
   return match;

--- a/lib/rules_inline/entity.js
+++ b/lib/rules_inline/entity.js
@@ -2,8 +2,7 @@
 
 'use strict';
 
-var entities          = require('../common/entities');
-var has               = require('../common/utils').has;
+var decodeHTML        = require('entities').decodeHTML;
 var isValidEntityCode = require('../common/utils').isValidEntityCode;
 var fromCodePoint     = require('../common/utils').fromCodePoint;
 
@@ -13,7 +12,7 @@ var NAMED_RE   = /^&([a-z][a-z0-9]{1,31});/i;
 
 
 module.exports = function entity(state, silent) {
-  var ch, code, match, token, pos = state.pos, max = state.posMax;
+  var ch, code, match, decoded, token, pos = state.pos, max = state.posMax;
 
   if (state.src.charCodeAt(pos) !== 0x26/* & */) return false;
 
@@ -38,10 +37,11 @@ module.exports = function entity(state, silent) {
   } else {
     match = state.src.slice(pos).match(NAMED_RE);
     if (match) {
-      if (has(entities, match[1])) {
+      decoded = decodeHTML(match[0]);
+      if (decoded !== match[0]) {
         if (!silent) {
           token         = state.push('text_special', '', 0);
-          token.content = entities[match[1]];
+          token.content = decoded;
           token.markup  = match[0];
           token.info    = 'entity';
         }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "argparse": "^2.0.1",
-    "entities": "~3.0.1",
+    "entities": "^4.4.0",
     "linkify-it": "^4.0.1",
     "mdurl": "^1.0.1",
     "uc.micro": "^1.0.5"


### PR DESCRIPTION
Resolves #900, by updating `entities` to the 4.x major version.

This should also resolve #916 and resolve #958 as those are a result of the loose version pin for `entities`, resulting in some folks using 4.x already.

This includes a slight change to the order of operations in `replaceEntityPattern`, ensuring that the custom digital entity handling happens first (including bailing out early if the logic determines it to be an invalid code point, as `decodeHTML` from `entities` would "blindly" decode it -- this seems to now more closely follow how `lib/rules_inline/entity.js` already operated). This change was needed to keep the `markdown-it fatal.txt line 17` spec passing.