### PR TITLE
Moved `hljs` class to `<code>` from `<pre>`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ var md = require('markdown-it')({
 });
 ```
 
-Or with full wrapper override (if you need assign class to `<pre>`):
+Or with full wrapper override (if you need assign class to `<pre>` or `<code>`):
 
 ```js
 var hljs = require('highlight.js'); // https://highlightjs.org
@@ -171,13 +171,13 @@ var md = require('markdown-it')({
   highlight: function (str, lang) {
     if (lang && hljs.getLanguage(lang)) {
       try {
-        return '<pre class="hljs"><code>' +
+        return '<pre><code class="hljs">' +
                hljs.highlight(str, { language: lang, ignoreIllegals: true }).value +
                '</code></pre>';
       } catch (__) {}
     }
 
-    return '<pre class="hljs"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
+    return '<pre><code class="hljs">' + md.utils.escapeHtml(str) + '</code></pre>';
   }
 });
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,7 @@ function normalizeLinkText(url) {
  * });
  * ```
  *
- * Or with full wrapper override (if you need assign class to `<pre>`):
+ * Or with full wrapper override (if you need assign class to `<pre>` or `<code>`):
  *
  * ```javascript
  * var hljs = require('highlight.js') // https://highlightjs.org/
@@ -207,13 +207,13 @@ function normalizeLinkText(url) {
  *   highlight: function (str, lang) {
  *     if (lang && hljs.getLanguage(lang)) {
  *       try {
- *         return '<pre class="hljs"><code>' +
+ *         return '<pre><code class="hljs">' +
  *                hljs.highlight(str, { language: lang, ignoreIllegals: true }).value +
  *                '</code></pre>';
  *       } catch (__) {}
  *     }
  *
- *     return '<pre class="hljs"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
+ *     return '<pre><code class="hljs">' + md.utils.escapeHtml(str) + '</code></pre>';
  *   }
  * });
  * ```

--- a/support/api_header.md
+++ b/support/api_header.md
@@ -126,7 +126,7 @@ var md = require('markdown-it')({
 });
 ```
 
-Or with full wrapper override (if you need assign class to `<pre>`):
+Or with full wrapper override (if you need assign class to `<pre>` or `<code>`):
 
 ```js
 var hljs = require('highlight.js') // https://highlightjs.org/
@@ -136,13 +136,13 @@ var md = require('markdown-it')({
   highlight: function (str, lang) {
     if (lang && hljs.getLanguage(lang)) {
       try {
-        return '<pre class="hljs"><code>' +
+        return '<pre><code class="hljs">' +
                hljs.highlight(str, { language: lang, ignoreIllegals: true }).value +
                '</code></pre>';
       } catch (__) {}
     }
 
-    return '<pre class="hljs"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
+    return '<pre><code class="hljs">' + md.utils.escapeHtml(str) + '</code></pre>';
   }
 });
 ```

--- a/support/demo_template/index.js
+++ b/support/demo_template/index.js
@@ -107,7 +107,7 @@ defaults.highlight = function (str, lang) {
     }
   } catch (__) { /**/ }
 
-  return '<pre class="hljs"><code>' + esc(str) + '</code></pre>';
+  return '<pre><code class="hljs">' + esc(str) + '</code></pre>';
 };
 
 function setOptionClass(name, val) {


### PR DESCRIPTION
In this change set I am changing the guidance in the README and in comments to put the class on the correct tag: `<code>`, not `<pre>`.

If you put the `hljs` class on `<pre>`, syntax highlighting does not use the correct padding.

You can see from the default CSS stylesheet in the highlight.js repo that the `hljs` tag is expected to be on the `<code>` tag:
https://github.com/highlightjs/highlight.js/blob/84719c17a51d7bb045f2df441b9c00f871f7c063/src/styles/default.css#L17-L25

All the official highlight.js examples have the `hljs` class on `<code>`:
https://highlightjs.org/static/demo/

This change doesn't affect the demo because (1) you overrode the `hljs` padding in your CSS and (2) even if you hadn't, you're using Bootstrap which also overrides `<pre>` padding.

Before change:
<img width="474" alt="image" src="https://user-images.githubusercontent.com/16927/214487147-87b183f0-fbd3-4e38-826e-2668b8ae3700.png">

After change:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/16927/214487185-e4045021-9d25-41ad-94d0-dc2dd90c45d7.png">

But here is an example from my own project where I discovered this issue. This project does not use Bootstrap or override the padding for `hljs`:

Before:
<img width="334" alt="image" src="https://user-images.githubusercontent.com/16927/214487697-3cbcd631-82a7-46a8-9968-3ce4813ff1c0.png">

After:
<img width="334" alt="image" src="https://user-images.githubusercontent.com/16927/214488047-bc7ea285-599a-425c-bded-8c21145f778b.png">

I should also mention a couple of other issues with the README that I did not address:

1. Under "Syntax highlighting," it gives a default recommendation and then a second one: "Or with full wrapper override." But for syntax highlighting to use the correct background color with highlight.js, the second code sample is the only one that will work because the first code sample doesn't include the `hljs` class anywhere.
2. ~The last line of the second code sample looks like it has a bug. It references `md` while it's still in the value being assigned to `md`.~

I didn't try to address either of these issues but I can make a separate PR for them if you agree.