### PR TITLE
Respect nested `<pre>` elements in `highlighted`

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -55,7 +55,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
     highlighted = escapeHtml(token.content);
   }
 
-  if (highlighted.indexOf('<pre') === 0) {
+  if (highlighted.indexOf('<pre') !== -1) {
     return highlighted + '\n';
   }
 


### PR DESCRIPTION
Fixes #269 

### The Problem

Right now, the renderer only skips wrapping the results for fenced code blocks in `<pre><code>` if the content of `highlighted` *starts* with a `<pre>` tag. 

There are valid use cases where the `highlighted` markup would start with a toplevel `<div>` instead of a `<pre>`. If you want to enhance the code display with additional actions (copy code, language badge), for [example](https://vitest.dev/config/).

### Invalid HTML possible

Right now, if the result of `highlighted` starts with a `<div>` for example, we get nested, redundant and invalid HTML as a result. `<pre>` tags inside a `<pre>` tag, a (block) `<div>` tag inside an (inline) `<code>` tag. For example when using [markdown-it-shiki](https://github.com/antfu/markdown-it-shiki) with light and dark mode themes:

```html
<pre>
  <code class="language-bash">
    <div class="shiki-container language-bash">
      <pre class="shiki min-dark" style="background-color: #1f1f1f" tabindex="0">
        <code>...</code>
      </pre>
      <pre class="shiki min-light" style="background-color: #ffffff" tabindex="0">
        <code>...</code>
      </pre>
    </div>
  </code>
</pre>
```

### The Desired Behavior

I would expect markdown-it to output valid HTML (without the wrapped markup from markdown-it):

```html
<div class="shiki-container language-bash">
  <pre class="shiki min-dark" style="background-color: #1f1f1f" tabindex="0">
    <code>...</code>
  </pre>
  <pre class="shiki min-light" style="background-color: #ffffff" tabindex="0">
    <code>...</code>
  </pre>
</div>
```

The current behavior tempts us to use hacks to achieve our desired HTML output. One would be to prepend the output with an empty `<pre hidden>` tag, so that markdown-it would skip wrapping it. The output would then look like this (notice the leading empty pre tag):

```html
<pre hidden></pre>
<div class="shiki-container language-bash">
  <pre class="shiki min-dark" style="background-color: #1f1f1f" tabindex="0">
    <code>...</code>
  </pre>
  <pre class="shiki min-light" style="background-color: #ffffff" tabindex="0">
    <code>...</code>
  </pre>
</div>
```

### The Proposed Solution

In my opinion, if `highlighted` contains a `<pre>` tag _somewhere, on any level_, it should be considered to be a valid code block and returned without wrapping it. This is what this PR is for.