### PR TITLE
Corrected paths to node_modules folder used by benchmark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,16 @@
 ### If you commit changes:
 
 1. Make sure all tests pass.
-2. Run `./benchmark/benchmark.js`, make sure that performance not degraded.
-3. DON'T include auto-generated browser files to commit.
+2. Install dependencies for benchmark:
+
+```
+npm i benchmark
+npm i commonmark
+npm i marked
+```
+
+3. Run `./benchmark/benchmark.js`, make sure that performance not degraded.
+4. DON'T include auto-generated browser files to commit.
 
 ### Other things:
 

--- a/benchmark/implementations/commonmark-reference/index.js
+++ b/benchmark/implementations/commonmark-reference/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var commonmark = require('../../extra/lib/node_modules/commonmark');
+var commonmark = require('../../../node_modules/commonmark');
 var parser = new commonmark.Parser();
 var renderer = new commonmark.HtmlRenderer();
 

--- a/benchmark/implementations/markdown-it-2.2.1-commonmark/index.js
+++ b/benchmark/implementations/markdown-it-2.2.1-commonmark/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var md = require('../../extra/lib/node_modules/markdown-it')('commonmark');
+var md = require('../../../node_modules/markdown-it')('commonmark');
 
 exports.run = function (data) {
   return md.render(data);

--- a/benchmark/implementations/marked/index.js
+++ b/benchmark/implementations/marked/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var marked = require('../../extra/lib/node_modules/marked');
+var marked = require('../../../node_modules/marked');
 
 exports.run = function (data) {
   return marked(data);


### PR DESCRIPTION
Closes #970 

**Code changes:**

- The following paths were corrected to point to the actual locations of node_modules:

![corrected paths](https://github.com/markdown-it/markdown-it/assets/98062538/b61dab97-8664-4a84-8b79-b4ca1820e886)

- Added instructions to Contributing.md to install dependencies for benchmark prior to running it

**Screenshot of `./benchmark/benchmark.js` successfully running after the fix:**

![benchmark successful run](https://github.com/markdown-it/markdown-it/assets/98062538/adfdabf9-214e-4541-8d17-c478c904454c)