### PR TITLE
fix: updated outdated link in comment of lib/common/html_blocks.js

### DIFF
--- a/lib/common/html_blocks.js
+++ b/lib/common/html_blocks.js
@@ -1,5 +1,5 @@
-// List of valid html blocks names, accorting to commonmark spec
-// http://jgm.github.io/CommonMark/spec.html#html-blocks
+// List of valid html blocks names, according to commonmark spec
+// https://spec.commonmark.org/0.30/#html-blocks
 
 'use strict';
 


### PR DESCRIPTION
Updated the comment in `lib/common/html_blocks.js` to have a working link.

Old link: http://jgm.github.io/CommonMark/spec.html#html-blocks

New link: https://spec.commonmark.org/0.30/#html-blocks