### PR TITLE
Render html tags inside img alt as their original text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [14.0.0] - WIP
+### Fixed
+- Html tokens inside img alt are now rendered as their original text, #896.
+- Hardbreaks inside img alt are now rendered as newlines.
+
+
 ## [13.0.2] - 2023-09-26
 ### Security
 - Fixed crash/infinite loop caused by linkify inline rule, #957.

--- a/lib/renderer.mjs
+++ b/lib/renderer.mjs
@@ -268,12 +268,23 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
   let result = ''
 
   for (let i = 0, len = tokens.length; i < len; i++) {
-    if (tokens[i].type === 'text') {
-      result += tokens[i].content
-    } else if (tokens[i].type === 'image') {
-      result += this.renderInlineAsText(tokens[i].children, options, env)
-    } else if (tokens[i].type === 'softbreak') {
-      result += '\n'
+    switch (tokens[i].type) {
+      case 'text':
+        result += tokens[i].content
+        break
+      case 'image':
+        result += this.renderInlineAsText(tokens[i].children, options, env)
+        break
+      case 'html_inline':
+      case 'html_block':
+        result += tokens[i].content
+        break
+      case 'softbreak':
+      case 'hardbreak':
+        result += '\n'
+        break
+      default:
+        // all other tokens are skipped
     }
   }
 

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -682,11 +682,27 @@ Issue #772. Header rule should not interfere with html tags.
 </pre>
 .
 
-Newline in image description
+Softbreak in image description
 .
 There is a newline in this image ![here
 it is](https://github.com/executablebooks/)
 .
 <p>There is a newline in this image <img src="https://github.com/executablebooks/" alt="here
 it is"></p>
+.
+
+Hardbreak in image description
+.
+There is a newline in this image ![here\
+it is](https://github.com/executablebooks/)
+.
+<p>There is a newline in this image <img src="https://github.com/executablebooks/" alt="here
+it is"></p>
+.
+
+Html in image description
+.
+![text <textarea> text](image.png)
+.
+<p><img src="image.png" alt="text &lt;textarea&gt; text"></p>
 .


### PR DESCRIPTION
See discussion in https://github.com/markdown-it/markdown-it/issues/896.

Spec is not clear on how to handle this. Three variations exist:

```sh
$ echo '![text <textarea> text](image.png)' | /home/user/commonmark.js/bin/commonmark
<p><img src="image.png" alt="text <textarea> text" /></p>

$ echo '![text <textarea> text](image.png)' | /home/user/cmark/build/src/cmark
<p><img src="image.png" alt="text &lt;textarea&gt; text" /></p>

$ echo '![text <textarea> text](image.png)' | /home/user/.local/bin/commonmark
<p><img src="image.png" alt="text  text" /></p>
```

Discussion in commonmark spec issue is inconclusive.

In addition to that, there's a small inconsistency in markdown-it output (with html option on or off there will be different result), which is going to raise questions.

This is not necessarily a final solution (still waiting on spec), but the following change seems reasonable:

Prior to this commit:
 - when HTML tags are enabled, tags were removed (as in Haskell version)
 - when HTML tags are disabled, tags were escaped (as in C version)

After this commit:
 - tags will be escaped (as in C version) regardless of HTML flag

Going with option 2 here. Not option 3, because people asked about this. Not option 1, because we escape `<>` inside attributes.

This commit also renders `hardbreak` token as newline - this is same as in commonmark reference implementation at this moment (not defined in spec).