### PR TITLE
Improve performance of reference definition list parsing

### DIFF
--- a/lib/parser_block.mjs
+++ b/lib/parser_block.mjs
@@ -22,15 +22,15 @@ import r_paragraph from './rules_block/paragraph.mjs'
 const _rules = [
   // First 2 params - rule name & source. Secondary array - list of rules,
   // which can be terminated by this one.
-  ['table',      r_table,      ['paragraph', 'reference']],
+  ['table',      r_table,      ['paragraph']],
   ['code',       r_code],
-  ['fence',      r_fence,      ['paragraph', 'reference', 'blockquote', 'list']],
-  ['blockquote', r_blockquote, ['paragraph', 'reference', 'blockquote', 'list']],
-  ['hr',         r_hr,         ['paragraph', 'reference', 'blockquote', 'list']],
-  ['list',       r_list,       ['paragraph', 'reference', 'blockquote']],
+  ['fence',      r_fence,      ['paragraph', 'blockquote', 'list']],
+  ['blockquote', r_blockquote, ['paragraph', 'blockquote', 'list']],
+  ['hr',         r_hr,         ['paragraph', 'blockquote', 'list']],
+  ['list',       r_list,       ['paragraph', 'blockquote']],
   ['reference',  r_reference],
-  ['html_block', r_html_block, ['paragraph', 'reference', 'blockquote']],
-  ['heading',    r_heading,    ['paragraph', 'reference', 'blockquote']],
+  ['html_block', r_html_block, ['paragraph', 'blockquote']],
+  ['heading',    r_heading,    ['paragraph', 'blockquote']],
   ['lheading',   r_lheading],
   ['paragraph',  r_paragraph]
 ]


### PR DESCRIPTION
Fixes https://github.com/markdown-it/markdown-it/issues/996

Looks like the reference definitions cannot interrupted by any of the elements if I read the spec correctly.

None of the tests fail.

By removing the redundant termination logic checks the speed of parsing long list of reference definitions improves dramatically.

~2.5x on the benchmark included in this repo, but in our example where we have 1000 definitions it's almost 20x!

**benchmark before**

```
./benchmark/benchmark.mjs block-ref-list
Selected samples: (1 of 28)
 > block-ref-list

Sample: block-ref-list.md (782 bytes)
 > commonmark-reference x 29,907 ops/sec ±0.24% (96 runs sampled)
 > current x 6,429 ops/sec ±0.23% (98 runs sampled)
 > current-commonmark x 7,261 ops/sec ±0.13% (98 runs sampled)
 > markdown-it-2.2.1-commonmark x 36,093 ops/sec ±0.20% (94 runs sampled)
 > marked x 55,087 ops/sec ±2.06% (99 runs sampled)
```

**benchmark after**


```
./benchmark/benchmark.mjs block-ref-list
Selected samples: (1 of 28)
 > block-ref-list

Sample: block-ref-list.md (782 bytes)
 > commonmark-reference x 29,025 ops/sec ±0.50% (94 runs sampled)
 > current x 15,550 ops/sec ±0.35% (94 runs sampled)
 > current-commonmark x 16,762 ops/sec ±0.63% (95 runs sampled)
 > markdown-it-2.2.1-commonmark x 35,562 ops/sec ±0.23% (91 runs sampled)
 > marked x 55,408 ops/sec ±0.18% (98 runs sampled)
```