### PR TITLE
Added link reference 'definition' token type

### DIFF
--- a/lib/renderer.mjs
+++ b/lib/renderer.mjs
@@ -187,7 +187,7 @@ Renderer.prototype.renderToken = function renderToken (tokens, idx, options) {
   //  - a
   //    >
   //
-  if (token.block && token.nesting !== -1 && idx && tokens[idx - 1].hidden) {
+  if (token.block && token.nesting !== -1 && idx && tokens[idx - 1].hidden && tokens[idx - 1].type !== 'definition') {
     result += '\n'
   }
 

--- a/lib/rules_block/reference.mjs
+++ b/lib/rules_block/reference.mjs
@@ -190,7 +190,8 @@ export default function reference (state, startLine, _endLine, silent) {
     return false
   }
 
-  const label = normalizeReference(str.slice(1, labelEnd))
+  const label_raw = str.slice(1, labelEnd)
+  const label = normalizeReference(label_raw)
   if (!label) {
     // CommonMark 0.20 disallows empty labels
     return false
@@ -208,5 +209,17 @@ export default function reference (state, startLine, _endLine, silent) {
   }
 
   state.line = nextLine
+
+  const token = state.push('definition', '', 0)
+  token.meta = {
+    label: label_raw,
+    destination: href,
+    title
+  }
+  token.map = [startLine, state.line]
+  token.block = true
+  token.hidden = true
+  token.children = []
+
   return true
 }

--- a/test/misc.mjs
+++ b/test/misc.mjs
@@ -539,4 +539,26 @@ describe('Definition', function () {
       { label: 'foo', destination: '', title: '' }
     )
   })
+
+  it('Should render nested link reference definition token', function () {
+    const md = markdownit()
+
+    assert.strictEqual(md.render('[foo]\n\n> [foo]: /url', {}), '<p><a href="/url">foo</a></p>\n<blockquote></blockquote>\n')
+
+    let tokens = md.parse('[foo]\n\n> [foo]: /url', {})
+    assert.strictEqual(type_filter(tokens, 'definition').length, 1)
+    tokens = type_filter(tokens, 'definition')
+    assert.deepEqual(
+      tokens[0].level,
+      1
+    )
+    assert.deepEqual(
+      tokens[0].map,
+      [2, 3]
+    )
+    assert.deepEqual(
+      tokens[0].meta,
+      { label: 'foo', destination: '/url', title: '' }
+    )
+  })
 })

--- a/test/misc.mjs
+++ b/test/misc.mjs
@@ -472,3 +472,71 @@ describe('Token attributes', function () {
     assert.strictEqual(t.attrGet('myattr'), 'myvalue')
   })
 })
+
+describe('Definition', function () {
+  function type_filter (tokens, type) {
+    return tokens.filter(function (t) { return t.type === type })
+  }
+
+  it('Should not render link reference definition', function () {
+    const md = markdownit()
+
+    assert.strictEqual(
+      md.render('[foo]: /url "title"\n\n[foo]', {}),
+      '<p><a href="/url" title="title">foo</a></p>\n'
+    )
+  })
+
+  it('Should not render newline after link reference definition', function () {
+    const md = markdownit()
+
+    assert.strictEqual(
+      md.render('[foo]: /url "title"\nbar', {}),
+      '<p>bar</p>\n'
+    )
+  })
+
+  it('Should add meta to link reference definition', function () {
+    const md = markdownit()
+
+    let tokens = md.parse('[foo]: /url "title"\n\n[foo]', {})
+    assert.strictEqual(type_filter(tokens, 'definition').length, 1)
+    tokens = type_filter(tokens, 'definition')
+    assert.deepEqual(
+      tokens[0].meta,
+      { label: 'foo', destination: '/url', title: 'title' }
+    )
+  })
+
+  it('Should add sourcemap info to link reference definition token', function () {
+    const md = markdownit()
+
+    let tokens = md.parse("[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]", {})
+    assert.strictEqual(type_filter(tokens, 'definition').length, 1)
+    tokens = type_filter(tokens, 'definition')
+    assert.deepEqual(
+      tokens[0].map,
+      [0, 5]
+    )
+    assert.deepEqual(
+      tokens[0].meta,
+      { label: 'foo', destination: '/url', title: '\ntitle\nline1\nline2\n' }
+    )
+  })
+
+  it('Empty link destination should be empty string in the link reference definition token', function () {
+    const md = markdownit()
+
+    let tokens = md.parse('[foo]: <>\n\n[foo]', {})
+    assert.strictEqual(type_filter(tokens, 'definition').length, 1)
+    tokens = type_filter(tokens, 'definition')
+    assert.deepEqual(
+      tokens[0].map,
+      [0, 1]
+    )
+    assert.deepEqual(
+      tokens[0].meta,
+      { label: 'foo', destination: '', title: '' }
+    )
+  })
+})


### PR DESCRIPTION
Added a new token type for link reference definition.

I needed definitions in the Markdown AST(token stream). Based on this [comment](https://github.com/markdown-it/markdown-it/issues/1050#issuecomment-2365359497) and its inclusion in the [Rust port](https://github.com/markdown-it-rust/markdown-it/blob/master/src/plugins/cmark/block/reference.rs#L365) here, figured it will be acceptable to add this as a feature.

