### PR TITLE
Ignore unreachable lines in modern Node in c8

### DIFF
--- a/lib/common/utils.mjs
+++ b/lib/common/utils.mjs
@@ -240,6 +240,7 @@ function normalizeReference (str) {
   // (remove this when node v10 is no longer supported).
   //
   if ('ẞ'.toLowerCase() === 'Ṿ') {
+    /* c8 ignore next 2 */
     str = str.replace(/ẞ/g, 'ß')
   }
 


### PR DESCRIPTION
From comments:

```js
// In node v10 'ẞ'.toLowerCase() === 'Ṿ', which is presumed to be a bug
// fixed in v12 (couldn't find any details).
//
// So treat this one as a special case
// (remove this when node v10 is no longer supported).
```

We should `c8 ignore` here.