### PR TITLE
Support disable validateLink in cli mode

### DIFF
--- a/bin/markdown-it.mjs
+++ b/bin/markdown-it.mjs
@@ -20,6 +20,11 @@ cli.add_argument('--no-html', {
   action: 'store_true'
 })
 
+cli.add_argument('--no-validate-link', {
+  help: 'Disable validate Link',
+  action: 'store_true'
+})
+
 cli.add_argument('-l', '--linkify', {
   help: 'Autolink text',
   action: 'store_true'
@@ -86,6 +91,10 @@ readFile(options.file, 'utf8', function (err, input) {
     typographer: options.typographer,
     linkify: options.linkify
   })
+
+  if (options.no_validate_link) {
+    md.validateLink = () => true
+  }
 
   try {
     output = md.render(input)


### PR DESCRIPTION
add `--no-validate-link` parameter to disable the validateLink in cli mode.

Fixes https://github.com/markdown-it/markdown-it/issues/1083

test.md

```
[hello]( <javascript:alert(1)> )
```

```sh
./bin/markdown-it.mjs test.md
<p>[hello]( &lt;javascript:alert(1)&gt; )</p

./bin/markdown-it.mjs --no-validate-link test.md
<p><a href="javascript:alert(1)">hello</a></p>
```