### PR TITLE
Do not process `&`-entities that don't end in `;`

### DIFF
--- a/lib/rules_inline/entity.mjs
+++ b/lib/rules_inline/entity.mjs
@@ -1,6 +1,6 @@
 // Process html entity - &#123;, &#xAF;, &quot;, ...
 
-import { decodeHTML } from 'entities'
+import { decodeHTMLStrict } from 'entities'
 import { isValidEntityCode, fromCodePoint } from '../common/utils.mjs'
 
 const DIGITAL_RE = /^&#((?:x[a-f0-9]{1,6}|[0-9]{1,7}));/i
@@ -33,7 +33,7 @@ export default function entity (state, silent) {
   } else {
     const match = state.src.slice(pos).match(NAMED_RE)
     if (match) {
-      const decoded = decodeHTML(match[0])
+      const decoded = decodeHTMLStrict(match[0])
       if (decoded !== match[0]) {
         if (!silent) {
           const token   = state.push('text_special', '', 0)

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -740,3 +740,19 @@ Html in image description
 .
 <p><img src="image.png" alt="text &lt;textarea&gt; text"></p>
 .
+
+
+https://github.com/commonmark/commonmark.js/pull/279
+
+.
+&parag;
+
+&para
+
+&para;
+.
+<p>&amp;parag;</p>
+<p>&amp;para</p>
+<p>¶</p>
+.
+


### PR DESCRIPTION
Same fix as <https://github.com/commonmark/commonmark.js/pull/279>, because both libraries use the same HTML entity parser in the same incorrect way.