### PR TITLE
feat: added `env` argument to `highlight` option

### DIFF
--- a/lib/renderer.mjs
+++ b/lib/renderer.mjs
@@ -40,7 +40,7 @@ default_rules.fence = function (tokens, idx, options, env, slf) {
 
   let highlighted
   if (options.highlight) {
-    highlighted = options.highlight(token.content, langName, langAttrs) || escapeHtml(token.content)
+    highlighted = options.highlight(token.content, langName, langAttrs, env) || escapeHtml(token.content)
   } else {
     highlighted = escapeHtml(token.content)
   }


### PR DESCRIPTION
Related #626
Fixed #1105, #499

Since the default `fence` rule callback has a `env` param, I think it would be better if it can pass to the `options.highlight` as well to provide additional context info.
