### PR TITLE
fix: always reset parentType in lheading rule

### DIFF
--- a/lib/rules_block/lheading.mjs
+++ b/lib/rules_block/lheading.mjs
@@ -57,6 +57,7 @@ export default function lheading (state, startLine, endLine/*, silent */) {
 
   if (!level) {
     // Didn't find valid underline
+    state.parentType = oldParentType
     return false
   }
 


### PR DESCRIPTION
Fixes https://github.com/markdown-it/markdown-it/issues/1130