### PR TITLE
feat!: remove ddIndent property from state_block

### DIFF
--- a/lib/rules_block/state_block.mjs
+++ b/lib/rules_block/state_block.mjs
@@ -42,7 +42,6 @@ function StateBlock (src, md, env, tokens) {
   this.line       = 0 // line index in src
   this.lineMax    = 0 // lines count
   this.tight      = false  // loose/tight mode for lists
-  this.ddIndent   = -1 // indent of the current dd block (-1 if there isn't any)
   this.listIndent = -1 // indent of the current list block (-1 if there isn't any)
 
   // can be 'blockquote', 'list', 'root', 'paragraph' or 'reference'


### PR DESCRIPTION
closes https://github.com/markdown-it/markdown-it/issues/1139