### PR TITLE
fix: relaxed right-flanking check for CJK characters

### DIFF
--- a/lib/rules_inline/state_inline.mjs
+++ b/lib/rules_inline/state_inline.mjs
@@ -3,6 +3,17 @@
 import Token from '../token.mjs'
 import { isWhiteSpace, isPunctChar, isMdAsciiPunct } from '../common/utils.mjs'
 
+// Check if the character is a CJK character.
+//
+// ranges:
+// - 0x4E00 - 0x9FFF : CJK Unified Ideographs
+// - 0xAC00 - 0xD7A3 : Hangul Syllables
+//
+function isCJK (code) {
+  return (code >= 0x4E00 && code <= 0x9FFF) ||
+         (code >= 0xAC00 && code <= 0xD7A3)
+}
+
 function StateInline (src, md, env, outTokens) {
   this.src = src
   this.env = env
@@ -106,10 +117,12 @@ StateInline.prototype.scanDelims = function (start, canSplitWord) {
   const isLastWhiteSpace = isWhiteSpace(lastChar)
   const isNextWhiteSpace = isWhiteSpace(nextChar)
 
+  const isNextCJK = isCJK(nextChar)
+
   const left_flanking =
     !isNextWhiteSpace && (!isNextPunctChar || isLastWhiteSpace || isLastPunctChar)
   const right_flanking =
-    !isLastWhiteSpace && (!isLastPunctChar || isNextWhiteSpace || isNextPunctChar)
+    !isLastWhiteSpace && (!isLastPunctChar || isNextWhiteSpace || isNextPunctChar || isNextCJK)
 
   const can_open  = left_flanking  && (canSplitWord || !right_flanking || isLastPunctChar)
   const can_close = right_flanking && (canSplitWord || !left_flanking  || isNextPunctChar)


### PR DESCRIPTION
## Motivation
In CJK languages, grammatical particles (e.g., `는`, `가`) often attach directly to the preceding token without a space.
Currently, `markdown-it` fails to recognize a closing emphasis delimiter if it is preceded by punctuation and immediately followed by a CJK character (e.g., `**JWT)**는`).

This occurs because the current [scanDelims](cci:1://file:///c:/markdown-it/lib/rules_inline/state_inline.mjs:92:0-130:1) logic strictly follows CommonMark rules for "right-flanking delimiter runs". It interprets the sequence `Punctuation` + `Delimiter` + `Letter (CJK)` as a non-closing condition (similar to intra-word delimiters like `a**b**c`), preventing the emphasis from closing.

## Changes
- Introduced an [isCJK(code)](cci:1://file:///c:/markdown-it/lib/rules_inline/state_inline.mjs:5:0-14:1) helper in [lib/rules_inline/state_inline.mjs](cci:7://file:///c:/markdown-it/lib/rules_inline/state_inline.mjs:0:0-0:0) to detect CJK Unified Ideographs and Hangul Syllables.
- Modified `StateInline.prototype.scanDelims` to treat the delimiter as **right-flanking** (valid closer) if the following character is a CJK character, regardless of the preceding character.

## Verification

### Correctness
- **Issue Case Fixed:** `**JWT(JSON Web Token)**는` now correctly renders as `<strong>JWT(JSON Web Token)</strong>는`.
- **Safety Check:**
    - Standard intra-word emphasis (e.g., `in**tra**word`) remains unaffected.
    - Underscore strictness rules (e.g., `__test)__는`) are preserved (underscores are not allowed to close in this context due to stricter Left-Flanking rules), preventing unintended formatting in code-like strings.

<img width="1108" height="869" alt="스크린샷 2026-01-04 190315" src="https://github.com/user-attachments/assets/c04c7075-b5e6-40b4-a52e-ebee4ca452a9" />

### Performance (Benchmarks)
Ran [./benchmark/benchmark.mjs](cci:7://file:///c:/markdown-it/benchmark/benchmark.mjs:0:0-0:0) to ensure no performance degradation.
- **Baseline:** ~24,400 ops/sec
- **Patched:** ~24,400 ops/sec
**Result:** No measurable regression.