### PR TITLE
Fix HTML comment blocks in list items (issue #1144)

### DIFF
--- a/lib/rules_block/html_block.mjs
+++ b/lib/rules_block/html_block.mjs
@@ -46,7 +46,10 @@ export default function html_block (state, startLine, endLine, silent) {
   // Let's roll down till block end.
   if (!HTML_SEQUENCES[i][1].test(lineText)) {
     for (; nextLine < endLine; nextLine++) {
-      if (state.sCount[nextLine] < state.blkIndent) { break }
+      if (state.sCount[nextLine] < state.blkIndent) {
+        // Allow empty lines to stay inside list items per CommonMark rules.
+        if (!(state.listIndent >= 0 && state.isEmpty(nextLine))) { break }
+      }
 
       pos = state.bMarks[nextLine] + state.tShift[nextLine]
       max = state.eMarks[nextLine]

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -740,3 +740,29 @@ Html in image description
 .
 <p><img src="image.png" alt="text &lt;textarea&gt; text"></p>
 .
+
+Issue #1144: HTML comment block in list item with blank line
+.
+1. item
+
+    para
+    <!--
+    a
+
+    b
+    -->
+    c
+.
+<ol>
+<li>
+<p>item</p>
+<p>para</p>
+ <!--
+ a
+
+ b
+ -->
+<p>c</p>
+</li>
+</ol>
+.


### PR DESCRIPTION
## Summary
- Prevent HTML comment blocks (type 2) from terminating early on blank lines inside list items.
- Add a regression fixture for issue #1144.

## Details
The HTML block parser currently ends when it sees an outdented line. Inside list items, blank lines can be outdented but still belong to the list item, which causes `<!-- ... -->` blocks to end before `-->`. This change allows empty lines to remain inside HTML blocks when parsing list items, matching CommonMark’s type 2 rules.

## Testing
- npm test
- npm run benchmark-deps
- ./benchmark/benchmark.mjs
