### PR TITLE
fix: don't end HTML comment blocks on a blank line

### DIFF
--- a/lib/rules_block/html_block.mjs
+++ b/lib/rules_block/html_block.mjs
@@ -42,11 +42,22 @@ export default function html_block (state, startLine, endLine, silent) {
 
   let nextLine = startLine + 1
 
+  // Block types 6 and 7 (the only ones whose end condition is a blank line)
+  // have `/^$/` as their closing regexp. For all other types (1-5, e.g.
+  // `<!--` comments), a blank line is regular content and must not terminate
+  // the block - it ends only when its closing sequence is found.
+  const endsOnBlankLine = HTML_SEQUENCES[i][1].test('')
+
   // If we are here - we detected HTML block.
   // Let's roll down till block end.
   if (!HTML_SEQUENCES[i][1].test(lineText)) {
     for (; nextLine < endLine; nextLine++) {
-      if (state.sCount[nextLine] < state.blkIndent) { break }
+      if (state.sCount[nextLine] < state.blkIndent) {
+        // An outdented blank line shouldn't end a block that doesn't end on a
+        // blank line (e.g. a `<!--` comment inside a list item). Such blocks
+        // must continue until their closing sequence regardless of indent.
+        if (endsOnBlankLine || !state.isEmpty(nextLine)) { break }
+      }
 
       pos = state.bMarks[nextLine] + state.tShift[nextLine]
       max = state.eMarks[nextLine]

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -791,3 +791,46 @@ a*a𐬼*a
 <p>a*𐬼a*a</p>
 <p>a*a𐬼*a</p>
 .
+
+Issue #1144. Comment HTML block (type 2) must not end on a blank line inside a list
+.
+1. item
+
+    <!--
+    a
+
+    b
+    -->
+    c
+.
+<ol>
+<li>
+<p>item</p>
+ <!--
+ a
+
+ b
+ -->
+<p>c</p>
+</li>
+</ol>
+.
+
+Issue #1144. Comment HTML block spanning a blank line inside a blockquote
+.
+> <!--
+> a
+>
+> b
+> -->
+> c
+.
+<blockquote>
+<!--
+a
+
+b
+-->
+<p>c</p>
+</blockquote>
+.


### PR DESCRIPTION
## Problem
An HTML block of types 1-5 (e.g. a `<!-- ... -->` comment) should continue until its closing sequence (`-->`), per CommonMark; only block types 6 and 7 end on a blank line. Inside a container such as a list item, a blank line is outdented (`sCount` 0), so the scanner terminated a comment block early instead of running to `-->`.

## Fix
Detect whether the matched HTML block type actually ends on a blank line (its closing regexp matches the empty string). For types that do not, an outdented blank line is treated as regular block content rather than a terminator, so comment blocks no longer depend on indentation.

## Tests
Added regression fixtures for #1144. Full CommonMark conformance suite passes (652/652).

Closes #1144