### PR TITLE
chore: Update entities dependency version to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "argparse": "^2.0.1",
-    "entities": "^4.4.0",
+    "entities": "^8.0.0",
     "linkify-it": "^5.0.0",
     "mdurl": "^2.0.0",
     "punycode.js": "^2.3.1",


### PR DESCRIPTION
fix #1107, which reference source files on GitHub in some old versions.