### PR TITLE
docs(state_block): add TODO to remove legacy ddIndent field

### DIFF
--- a/lib/rules_block/state_block.mjs
+++ b/lib/rules_block/state_block.mjs
@@ -42,6 +42,8 @@ function StateBlock (src, md, env, tokens) {
   this.line       = 0 // line index in src
   this.lineMax    = 0 // lines count
   this.tight      = false  // loose/tight mode for lists
+  // TODO(#1139): ddIndent is only mutated by markdown-it-deflist, not core.
+  // Consider removing from StateBlock after a side-effect review (post-TS migration).
   this.ddIndent   = -1 // indent of the current dd block (-1 if there isn't any)
   this.listIndent = -1 // indent of the current list block (-1 if there isn't any)
 


### PR DESCRIPTION
Fixes #1139 (interim TODO per maintainer request)