### PR TITLE
chore(deps): upgrade entities to ^4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "argparse": "^2.0.1",
-    "entities": "^4.4.0",
+    "entities": "^4.5.0",
     "linkify-it": "^5.0.1",
     "mdurl": "^2.0.0",
     "punycode.js": "^2.3.1",


### PR DESCRIPTION
## Summary

Fixes #1159

Bumps `entities` from `^4.4.0` to `^4.5.0`. Newer releases reference local distribution files in source maps instead of GitHub URLs, which avoids `source-map-loader` / webpack build warnings reported in #1107.

## Test plan

- [x] `npm test` — all tests passed locally