### PR TITLE
fix(benchmark): explain missing benchmark dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ### If you commit changes:
 
 1. Make sure all tests pass.
-2. Run `./benchmark/benchmark.mjs`, make sure that performance not degraded.
+2. Run `npm run benchmark-deps`, then `./benchmark/benchmark.mjs`, make sure that performance not degraded.
 3. DON'T include auto-generated browser files to commit.
 
 ### Other things:

--- a/benchmark/benchmark.mjs
+++ b/benchmark/benchmark.mjs
@@ -11,9 +11,21 @@ const IMPLS = []
 
 for (const name of fs.readdirSync(new URL('./implementations', import.meta.url)).sort()) {
   const filepath = new URL(`./implementations/${name}/index.mjs`, import.meta.url)
-  const code = (await import(filepath))
 
-  IMPLS.push({ name, code })
+  try {
+    const code = (await import(filepath))
+    IMPLS.push({ name, code })
+  } catch (error) {
+    if (error?.code === 'MODULE_NOT_FOUND') {
+      console.error(
+        'Benchmark dependencies are missing. Run `npm run benchmark-deps` first.\n' +
+        `Failed to load implementation "${name}": ${error.message}`
+      )
+      process.exit(1)
+    }
+
+    throw error
+  }
 }
 
 const SAMPLES = []


### PR DESCRIPTION
## Summary

Fixes #973

Running `./benchmark/benchmark.mjs` without installing benchmark deps fails with a confusing module-not-found stack trace. This adds a clear error message pointing to `npm run benchmark-deps` and documents the step in CONTRIBUTING.md.

## Test plan

- [x] Verified missing-deps path prints actionable error
- [x] `npm test` — all tests passed