### PR TITLE
fix(inline): honor escaped chars in linkify autolinks

### DIFF
--- a/lib/rules_inline/linkify.mjs
+++ b/lib/rules_inline/linkify.mjs
@@ -3,6 +3,46 @@
 // RFC3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 const SCHEME_RE = /(?:^|[^a-z0-9.+-])([a-z][a-z0-9.+-]*)$/i
 
+const ESCAPED = new Set('\\!"#$%&\'()*+,./:;<=>?@[]^_`{|}~-'.split(''))
+
+function unescapeForLinkify (src, start, max) {
+  let text = ''
+
+  for (let i = start; i < max; i++) {
+    if (src.charCodeAt(i) === 0x5C/* \ */ && i + 1 < max) {
+      const ch = src[i + 1]
+
+      if (ESCAPED.has(ch)) {
+        text += ch
+        i++
+        continue
+      }
+    }
+
+    text += src[i]
+  }
+
+  return text
+}
+
+function srcLengthForUnescaped (src, start, unescapedLength) {
+  let i = start
+  let consumed = 0
+
+  while (consumed < unescapedLength && i < src.length) {
+    if (src.charCodeAt(i) === 0x5C/* \ */ && i + 1 < src.length && ESCAPED.has(src[i + 1])) {
+      i += 2
+      consumed++
+      continue
+    }
+
+    i++
+    consumed++
+  }
+
+  return i - start
+}
+
 export default function linkify (state, silent) {
   if (!state.md.options.linkify) return false
   if (state.linkLevel > 0) return false
@@ -20,7 +60,9 @@ export default function linkify (state, silent) {
 
   const proto = match[1]
 
-  const link = state.md.linkify.matchAtStart(state.src.slice(pos - proto.length))
+  const sliceStart = pos - proto.length
+  const unescapedSlice = unescapeForLinkify(state.src, sliceStart, max)
+  const link = state.md.linkify.matchAtStart(unescapedSlice)
   if (!link) return false
 
   let url = link.url
@@ -58,6 +100,6 @@ export default function linkify (state, silent) {
     token_c.info = 'auto'
   }
 
-  state.pos += url.length - proto.length
+  state.pos += srcLengthForUnescaped(state.src, pos, url.length - proto.length)
   return true
 }

--- a/test/fixtures/markdown-it/linkify.txt
+++ b/test/fixtures/markdown-it/linkify.txt
@@ -174,3 +174,11 @@ i.org[x[x][xx: htt://a.b://a
 .
 <p><a href="http://i.org">i.org</a>[x[x][xx: htt://a.b://a</p>
 .
+
+
+linkify escaped characters inside url
+.
+See https://git\-scm.com/docs/gitignore\#\_pattern\_format.
+.
+<p>See <a href="https://git-scm.com/docs/gitignore#_pattern_format">https://git-scm.com/docs/gitignore#_pattern_format</a>.</p>
+.


### PR DESCRIPTION
## Summary

Fixes #1058

Inline linkify now unescapes markdown escape sequences before matching autolinks and advances the parser using the escaped source length. URLs such as `https://git\-scm.com/docs/gitignore\#\_pattern\_format` linkify correctly again.

## Test plan

- [x] Added fixture: `linkify escaped characters inside url`
- [x] `npm test` — all tests passed