### PR TITLE
fix(cjs): expose Token class on MarkdownIt.Token

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,1 +1,2 @@
 export { default } from './lib/index.mjs'
+export { default as Token } from './lib/token.mjs'

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,5 +1,6 @@
 // Main parser class
 
+import Token from './token.mjs'
 import * as utils from './common/utils.mjs'
 import * as helpers from './helpers/index.mjs'
 import Renderer from './renderer.mjs'
@@ -561,5 +562,7 @@ MarkdownIt.prototype.renderInline = function (src, env) {
 
   return this.renderer.render(this.parseInline(src, env), this.options, env)
 }
+
+MarkdownIt.Token = Token
 
 export default MarkdownIt

--- a/support/rollup.config.mjs
+++ b/support/rollup.config.mjs
@@ -44,7 +44,7 @@ const config_umd_full = {
 }
 
 const config_cjs_no_deps = {
-  input: 'index.mjs',
+  input: 'lib/index.mjs',
   output: {
     file: 'dist/index.cjs.js',
     format: 'cjs'

--- a/test/build/build.test.mjs
+++ b/test/build/build.test.mjs
@@ -18,3 +18,14 @@ describe('CJS', () => {
     assert.ok(new MarkdownIt.Token('test', '', 0) instanceof MarkdownIt.Token)
   })
 })
+
+describe('UMD', () => {
+  it('export Token class for script tag bundle', () => {
+    const umd = require('../../dist/markdown-it.js')
+    const MarkdownIt = umd.default || umd
+
+    assert.ok(MarkdownIt.Token)
+    assert.strictEqual(typeof MarkdownIt.Token, 'function')
+    assert.ok(new MarkdownIt.Token('test', '', 0) instanceof MarkdownIt.Token)
+  })
+})

--- a/test/build/build.test.mjs
+++ b/test/build/build.test.mjs
@@ -9,4 +9,12 @@ describe('CJS', () => {
   it('require', () => {
     assert.strictEqual(md.render('abc'), '<p>abc</p>\n')
   })
+
+  it('export Token class', () => {
+    const MarkdownIt = require('../../dist/index.cjs.js')
+
+    assert.ok(MarkdownIt.Token)
+    assert.strictEqual(typeof MarkdownIt.Token, 'function')
+    assert.ok(new MarkdownIt.Token('test', '', 0) instanceof MarkdownIt.Token)
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #1057

Expose the internal `Token` class as `MarkdownIt.Token` for CommonJS consumers (`require('markdown-it')`) and as a named ESM export. CJS bundle now builds from `lib/index.mjs` to keep `require('markdown-it')` callable as before.

## Test plan

- [x] Added CJS regression test for `MarkdownIt.Token`
- [x] `npm test` — all tests passed

Also fixes #990 for browser/UMD consumers via \`markdownit.Token\`.