### PR TITLE
fix: skip code block indent checks when code rule is disabled

### DIFF
--- a/lib/parser_block.mjs
+++ b/lib/parser_block.mjs
@@ -126,6 +126,9 @@ ParserBlock.prototype.parse = function (src, md, env, outTokens) {
 
   const state = new this.State(src, md, env, outTokens)
 
+  const codeRuleIdx = md.block.ruler.__find__('code')
+  state.maxCodeIndent = (codeRuleIdx >= 0 && md.block.ruler.__rules__[codeRuleIdx].enabled) ? 4 : Infinity
+
   this.tokenize(state, state.line, state.lineMax)
 }
 

--- a/lib/rules_block/blockquote.mjs
+++ b/lib/rules_block/blockquote.mjs
@@ -9,7 +9,7 @@ export default function blockquote (state, startLine, endLine, silent) {
   const oldLineMax = state.lineMax
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
 
   // check the block quote marker
   if (state.src.charCodeAt(pos) !== 0x3E/* > */) { return false }

--- a/lib/rules_block/code.mjs
+++ b/lib/rules_block/code.mjs
@@ -1,7 +1,7 @@
 // Code block (4 spaces padded)
 
 export default function code (state, startLine, endLine/*, silent */) {
-  if (state.sCount[startLine] - state.blkIndent < 4) { return false }
+  if (state.sCount[startLine] - state.blkIndent < state.maxCodeIndent) { return false }
 
   let nextLine = startLine + 1
   let last = nextLine
@@ -12,7 +12,7 @@ export default function code (state, startLine, endLine/*, silent */) {
       continue
     }
 
-    if (state.sCount[nextLine] - state.blkIndent >= 4) {
+    if (state.isCodeBlock(nextLine)) {
       nextLine++
       last = nextLine
       continue

--- a/lib/rules_block/fence.mjs
+++ b/lib/rules_block/fence.mjs
@@ -5,7 +5,7 @@ export default function fence (state, startLine, endLine, silent) {
   let max = state.eMarks[startLine]
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
 
   if (pos + 3 > max) { return false }
 
@@ -59,7 +59,7 @@ export default function fence (state, startLine, endLine, silent) {
 
     if (state.src.charCodeAt(pos) !== marker) { continue }
 
-    if (state.sCount[nextLine] - state.blkIndent >= 4) {
+    if (state.isCodeBlock(nextLine)) {
       // closing fence should be indented less than 4 spaces
       continue
     }

--- a/lib/rules_block/heading.mjs
+++ b/lib/rules_block/heading.mjs
@@ -7,7 +7,7 @@ export default function heading (state, startLine, endLine, silent) {
   let max = state.eMarks[startLine]
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
 
   let ch  = state.src.charCodeAt(pos)
 

--- a/lib/rules_block/hr.mjs
+++ b/lib/rules_block/hr.mjs
@@ -5,7 +5,7 @@ import { isSpace } from '../common/utils.mjs'
 export default function hr (state, startLine, endLine, silent) {
   const max = state.eMarks[startLine]
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
 
   let pos = state.bMarks[startLine] + state.tShift[startLine]
   const marker = state.src.charCodeAt(pos++)

--- a/lib/rules_block/html_block.mjs
+++ b/lib/rules_block/html_block.mjs
@@ -21,7 +21,7 @@ export default function html_block (state, startLine, endLine, silent) {
   let max = state.eMarks[startLine]
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
 
   if (!state.md.options.html) { return false }
 

--- a/lib/rules_block/lheading.mjs
+++ b/lib/rules_block/lheading.mjs
@@ -6,7 +6,7 @@ export default function lheading (state, startLine, endLine/*, silent */) {
   const terminatorRules = state.md.block.ruler.getRules('paragraph')
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
 
   const oldParentType = state.parentType
   state.parentType = 'paragraph' // use paragraph to match terminatorRules

--- a/lib/rules_block/list.mjs
+++ b/lib/rules_block/list.mjs
@@ -93,7 +93,7 @@ export default function list (state, startLine, endLine, silent) {
   let tight = true
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[nextLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(nextLine)) { return false }
 
   // Special case:
   //  - item 1
@@ -284,7 +284,7 @@ export default function list (state, startLine, endLine, silent) {
     if (state.sCount[nextLine] < state.blkIndent) { break }
 
     // if it's indented more than 3 spaces, it should be a code block
-    if (state.sCount[nextLine] - state.blkIndent >= 4) { break }
+    if (state.isCodeBlock(nextLine)) { break }
 
     // fail if terminating block found
     let terminate = false

--- a/lib/rules_block/reference.mjs
+++ b/lib/rules_block/reference.mjs
@@ -6,7 +6,7 @@ export default function reference (state, startLine, _endLine, silent) {
   let nextLine = startLine + 1
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
 
   if (state.src.charCodeAt(pos) !== 0x5B/* [ */) { return false }
 

--- a/lib/rules_block/state_block.mjs
+++ b/lib/rules_block/state_block.mjs
@@ -51,6 +51,10 @@ function StateBlock (src, md, env, tokens) {
 
   this.level = 0
 
+  // Max indent (spaces) treated as an indented code block line.
+  // Set to 4 when the `code` block rule is enabled, otherwise Infinity.
+  this.maxCodeIndent = 4
+
   // Create caches
   // Generate markers.
   const s = this.src
@@ -114,6 +118,11 @@ StateBlock.prototype.push = function (type, tag, nesting) {
 
 StateBlock.prototype.isEmpty = function isEmpty (line) {
   return this.bMarks[line] + this.tShift[line] >= this.eMarks[line]
+}
+
+// Returns true if line is indented enough to be parsed as a code block.
+StateBlock.prototype.isCodeBlock = function isCodeBlock (line) {
+  return (this.sCount[line] - this.blkIndent) >= this.maxCodeIndent
 }
 
 StateBlock.prototype.skipEmptyLines = function skipEmptyLines (from) {

--- a/lib/rules_block/table.mjs
+++ b/lib/rules_block/table.mjs
@@ -61,7 +61,7 @@ export default function table (state, startLine, endLine, silent) {
   if (state.sCount[nextLine] < state.blkIndent) { return false }
 
   // if it's indented more than 3 spaces, it should be a code block
-  if (state.sCount[nextLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(nextLine)) { return false }
 
   // first character of the second line should be '|', '-', ':',
   // and no other characters are allowed but spaces;
@@ -119,7 +119,7 @@ export default function table (state, startLine, endLine, silent) {
 
   lineText = getLine(state, startLine).trim()
   if (lineText.indexOf('|') === -1) { return false }
-  if (state.sCount[startLine] - state.blkIndent >= 4) { return false }
+  if (state.isCodeBlock(startLine)) { return false }
   columns = escapedSplit(lineText)
   if (columns.length && columns[0] === '') columns.shift()
   if (columns.length && columns[columns.length - 1] === '') columns.pop()
@@ -181,7 +181,7 @@ export default function table (state, startLine, endLine, silent) {
     if (terminate) { break }
     lineText = getLine(state, nextLine).trim()
     if (!lineText) { break }
-    if (state.sCount[nextLine] - state.blkIndent >= 4) { break }
+    if (state.isCodeBlock(nextLine)) { break }
     columns = escapedSplit(lineText)
     if (columns.length && columns[0] === '') columns.shift()
     if (columns.length && columns[columns.length - 1] === '') columns.pop()

--- a/test/markdown-it/misc.test.mjs
+++ b/test/markdown-it/misc.test.mjs
@@ -472,4 +472,26 @@ describe('Token attributes', function () {
 
     assert.strictEqual(t.attrGet('myattr'), 'myvalue')
   })
+
+  it('disable code rule skips indented code block checks (#1014)', function () {
+    const md = markdownit()
+    md.disable('code')
+
+    const src = [
+      '# This renders a heading',
+      '',
+      '  # This also renders a heading',
+      '',
+      '    # This renders a heading too'
+    ].join('\n')
+
+    assert.strictEqual(
+      md.render(src),
+      [
+        '<h1>This renders a heading</h1>',
+        '<h1>This also renders a heading</h1>',
+        '<h1>This renders a heading too</h1>'
+      ].join('\n') + '\n'
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- Add `StateBlock.maxCodeIndent` (4 when `code` rule enabled, `Infinity` when disabled)
- Add `StateBlock.isCodeBlock(line)` helper and replace duplicated `sCount - blkIndent >= 4` checks across block rules
- Set `maxCodeIndent` in `ParserBlock.parse()` based on whether the `code` block rule is active

## Problem
Disabling the `code` rule only stopped code block rendering, but other block rules still treated 4-space-indented lines as code blocks — e.g. `    # heading` became a paragraph instead of a heading.

## Test plan
- [x] Added regression test in `test/markdown-it/misc.test.mjs`
- [x] Full test suite passes (`npm test`)

Fixes #1014