### PR TITLE
fix: remove Node.js 10 workaround from normalizeReference()

### DIFF
--- a/lib/common/utils.mjs
+++ b/lib/common/utils.mjs
@@ -237,17 +237,6 @@ function normalizeReference (str) {
   //
   str = str.trim().replace(/\s+/g, ' ')
 
-  // In node v10 'ẞ'.toLowerCase() === 'Ṿ', which is presumed to be a bug
-  // fixed in v12 (couldn't find any details).
-  //
-  // So treat this one as a special case
-  // (remove this when node v10 is no longer supported).
-  //
-  if ('ẞ'.toLowerCase() === 'Ṿ') {
-    /* c8 ignore next 2 */
-    str = str.replace(/ẞ/g, 'ß')
-  }
-
   // .toLowerCase().toUpperCase() should get rid of all differences
   // between letter variants.
   //


### PR DESCRIPTION
## Summary
- Remove the Node.js 10-specific `ẞ` lowercasing workaround from `normalizeReference()`

## Problem
The workaround was added for a Node.js 10 bug fixed in Node.js 12+. Node.js 10 reached EOL in 2021 and markdown-it is tested on Node.js 24.

## Test plan
- [x] Full test suite passes (`npm test`), including CommonMark fixtures with `ẞ` reference labels

Fixes #1153