### PR TITLE
feat: store normalized reference labels on link/image tokens

### DIFF
--- a/lib/rules_inline/image.mjs
+++ b/lib/rules_inline/image.mjs
@@ -5,6 +5,7 @@ import { normalizeReference, isSpace } from '../common/utils.mjs'
 export default function image (state, silent) {
   let code, content, label, pos, ref, res, title, start
   let href = ''
+  let referenceLabel = null
   const oldPos = state.pos
   const max = state.posMax
 
@@ -97,7 +98,8 @@ export default function image (state, silent) {
     // (collapsed reference link and shortcut reference link respectively)
     if (!label) { label = state.src.slice(labelStart, labelEnd) }
 
-    ref = state.env.references[normalizeReference(label)]
+    referenceLabel = normalizeReference(label)
+    ref = state.env.references[referenceLabel]
     if (!ref) {
       state.pos = oldPos
       return false
@@ -129,6 +131,10 @@ export default function image (state, silent) {
 
     if (title) {
       attrs.push(['title', title])
+    }
+
+    if (referenceLabel) {
+      token.meta = { label: referenceLabel }
     }
   }
 

--- a/lib/rules_inline/link.mjs
+++ b/lib/rules_inline/link.mjs
@@ -8,6 +8,7 @@ export default function link (state, silent) {
   let title = ''
   let start = state.pos
   let parseReference = true
+  let referenceLabel = null
 
   if (state.src.charCodeAt(state.pos) !== 0x5B/* [ */) { return false }
 
@@ -102,7 +103,8 @@ export default function link (state, silent) {
     // (collapsed reference link and shortcut reference link respectively)
     if (!label) { label = state.src.slice(labelStart, labelEnd) }
 
-    ref = state.env.references[normalizeReference(label)]
+    referenceLabel = normalizeReference(label)
+    ref = state.env.references[referenceLabel]
     if (!ref) {
       state.pos = oldPos
       return false
@@ -124,6 +126,10 @@ export default function link (state, silent) {
     token_o.attrs  = attrs
     if (title) {
       attrs.push(['title', title])
+    }
+
+    if (referenceLabel) {
+      token_o.meta = { label: referenceLabel }
     }
 
     state.linkLevel++

--- a/test/markdown-it/references.test.mjs
+++ b/test/markdown-it/references.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import markdownit from '../../index.mjs'
+
+describe('reference labels', function () {
+  it('stores normalized label on reference link and image tokens (#938)', function () {
+    const md = markdownit()
+    const src = '[a]: ijk\n\n[a]\n\n![a]'
+    const tokens = md.parse(src, {})
+
+    const linkOpen = tokens[1].children.find((token) => token.type === 'link_open')
+    const image = tokens[4].children.find((token) => token.type === 'image')
+
+    assert.deepEqual(linkOpen.meta, { label: 'A' })
+    assert.deepEqual(image.meta, { label: 'A' })
+  })
+
+  it('does not store label on inline links and images', function () {
+    const md = markdownit()
+    const linkTokens = md.parse('[a](xyz)', {})
+    const imageTokens = md.parse('![a](xyz)', {})
+
+    assert.strictEqual(linkTokens[1].children[0].meta, null)
+    assert.strictEqual(imageTokens[1].children[0].meta, null)
+  })
+})


### PR DESCRIPTION
## Summary
- Store the normalized reference label on `link_open` and `image` tokens as `token.meta.label`
- Only applies to reference-style links/images, not inline links

## Problem
Round-trip renderers (e.g. mdformat) need access to the original reference label after normalization. markdown-it-py upstreamed this feature; maintainer requested the JS port without an option flag.

## Test plan
- [x] Added `test/markdown-it/references.test.mjs`
- [x] Reference label tests pass

Fixes #938