### PR TITLE
fix(renderer): include inline code content in image alt text

### DIFF
--- a/lib/renderer.mjs
+++ b/lib/renderer.mjs
@@ -272,6 +272,9 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
       case 'text':
         result += tokens[i].content
         break
+      case 'code_inline':
+        result += tokens[i].content
+        break
       case 'image':
         result += this.renderInlineAsText(tokens[i].children, options, env)
         break

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -19,6 +19,13 @@ Strip markdown in ALT tags
 <p><img src="#" alt="strip markdown in alt"></p>
 .
 
+Issue #1142. Inline code in image alt
+.
+![foo *bar* `baz` bla](sample.png)
+.
+<p><img src="sample.png" alt="foo bar baz bla"></p>
+.
+
 Issue #55:
 .
 ![test]


### PR DESCRIPTION
## Summary
Include `code_inline` token content when flattening inline markup for image `alt` attributes.

## Problem
Fixes #1142. Markdown like `![foo *bar* \`baz\` bla](sample.png)` rendered as `alt="foo bar  bla"` — the backtick-wrapped word was dropped entirely.

CommonMark strips formatting but keeps plain text (same as emphasis). `renderInlineAsText` already handled `text` and nested `image` tokens but skipped `code_inline`.

## Fix
Add a `code_inline` case in `Renderer.prototype.renderInlineAsText` that appends `token.content`.

## Test plan
- [x] `npm test` — all tests pass
- [x] New fixture in `commonmark_extras.txt` for issue #1142 scenario