### PR TITLE
fix(renderer): render boolean HTML attributes without bogus values

### DIFF
--- a/lib/renderer.mjs
+++ b/lib/renderer.mjs
@@ -156,7 +156,14 @@ Renderer.prototype.renderAttrs = function renderAttrs (token) {
   result = ''
 
   for (i = 0, l = token.attrs.length; i < l; i++) {
-    result += ' ' + escapeHtml(token.attrs[i][0]) + '="' + escapeHtml(token.attrs[i][1]) + '"'
+    const name = escapeHtml(token.attrs[i][0])
+    const value = token.attrs[i][1]
+
+    if (value === null || value === undefined) {
+      result += ' ' + name
+    } else {
+      result += ' ' + name + '="' + escapeHtml(value) + '"'
+    }
   }
 
   return result

--- a/test/markdown-it/misc.test.mjs
+++ b/test/markdown-it/misc.test.mjs
@@ -458,6 +458,13 @@ describe('Token attributes', function () {
       md.renderer.render(tokens, md.options),
       '<pre><code class="bar"></code></pre>\n'
     )
+
+    t.attrPush(['download', null])
+
+    assert.strictEqual(
+      md.renderer.render(tokens, md.options),
+      '<pre><code class="bar" download></code></pre>\n'
+    )
   })
 
   it('.attrGet', function () {


### PR DESCRIPTION
## Summary
Support HTML boolean attributes in `Renderer.renderAttrs()` when extensions set `null` or omit attribute values.

## Problem
Fixes #598. Pushing `['download', null]` rendered as `download="null"`, and a one-element attr array rendered as `download="undefined"`. Extensions need `<a download>` style output.

## Fix
When an attribute value is `null` or `undefined`, emit the attribute name only (no `=""` and no stringified nullish values).

## Test plan
- [x] `npm test` — all tests pass
- [x] New regression in `Token attributes` for `download` with `null`