### PR TITLE
fix(list): exclude trailing blank lines from source maps

### DIFF
--- a/lib/rules_block/list.mjs
+++ b/lib/rules_block/list.mjs
@@ -87,6 +87,13 @@ function markTightParagraphs (state, idx) {
   }
 }
 
+function trimTrailingBlankLines (state, start, end) {
+  while (end > start + 1 && state.isEmpty(end - 1)) {
+    end--
+  }
+  return end
+}
+
 export default function list (state, startLine, endLine, silent) {
   let max, pos, start, token
   let nextLine = startLine
@@ -274,7 +281,7 @@ export default function list (state, startLine, endLine, silent) {
     token.markup = String.fromCharCode(markerCharCode)
 
     nextLine = state.line
-    itemLines[1] = nextLine
+    itemLines[1] = trimTrailingBlankLines(state, itemLines[0], nextLine)
 
     if (nextLine >= endLine) { break }
 
@@ -317,7 +324,7 @@ export default function list (state, startLine, endLine, silent) {
   }
   token.markup = String.fromCharCode(markerCharCode)
 
-  listLines[1] = nextLine
+  listLines[1] = trimTrailingBlankLines(state, listLines[0], nextLine)
   state.line = nextLine
 
   state.parentType = oldParentType

--- a/test/markdown-it/list-sourcemap.test.mjs
+++ b/test/markdown-it/list-sourcemap.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import MarkdownIt from '../../index.mjs'
+
+describe('list source maps', () => {
+  it('should not include trailing blank lines in list item maps', () => {
+    const md = new MarkdownIt()
+    const tokens = md.parse('- aaa\n\nbbb\n', {})
+
+    const listOpen = tokens.find(t => t.type === 'bullet_list_open')
+    const itemOpen = tokens.find(t => t.type === 'list_item_open')
+    const aaaParagraph = tokens.find(t => t.type === 'paragraph_open')
+
+    assert.deepEqual(listOpen.map, [0, 1])
+    assert.deepEqual(itemOpen.map, [0, 1])
+    assert.deepEqual(aaaParagraph.map, [0, 1])
+  })
+
+  it('should trim multiple trailing blank lines from list maps', () => {
+    const md = new MarkdownIt()
+    const tokens = md.parse('- aaa\n\n\n\n\n\n\n\n\nbbb\n', {})
+
+    const listOpen = tokens.find(t => t.type === 'bullet_list_open')
+    const itemOpen = tokens.find(t => t.type === 'list_item_open')
+
+    assert.deepEqual(listOpen.map, [0, 1])
+    assert.deepEqual(itemOpen.map, [0, 1])
+  })
+})


### PR DESCRIPTION
## Summary

- Trims trailing empty lines from `bullet_list_open` / `ordered_list_open` and `list_item_open` token maps
- Prevents list source maps from spanning blank lines between the item content and the next block

## Example

Before:

```js
md.parse('- aaa\n\nbbb\n')
// bullet_list_open.map === [0, 2]
// list_item_open.map === [0, 2]
```

After:

```js
md.parse('- aaa\n\nbbb\n')
// bullet_list_open.map === [0, 1]
// list_item_open.map === [0, 1]
```

Fixes #374

## Test plan

- [x] `npm test` passes
- [x] Added `test/markdown-it/list-sourcemap.test.mjs`