### PR TITLE
chore: remove outdated ddIndent from StateBlock

### DIFF
--- a/lib/rules_block/state_block.mjs
+++ b/lib/rules_block/state_block.mjs
@@ -42,7 +42,6 @@ function StateBlock (src, md, env, tokens) {
   this.line       = 0 // line index in src
   this.lineMax    = 0 // lines count
   this.tight      = false  // loose/tight mode for lists
-  this.ddIndent   = -1 // indent of the current dd block (-1 if there isn't any)
   this.listIndent = -1 // indent of the current list block (-1 if there isn't any)
 
   // can be 'blockquote', 'list', 'root', 'paragraph' or 'reference'


### PR DESCRIPTION
## Summary
- Remove unused `ddIndent` property from `StateBlock` in block parser state
- Property was leftover after definition lists moved to `markdown-it-deflist` and is not referenced anywhere in core

Fixes #1139

## Test plan
- [x] `npm test`