### PR TITLE
Remove legacy Node.js 10 workaround from `normalizeReference()`

### DIFF
--- a/lib/common/utils.mjs
+++ b/lib/common/utils.mjs
@@ -228,16 +228,6 @@ function normalizeReference (str) {
   //
   str = str.trim().replace(/\s+/g, ' ')
 
-  // In node v10 'ẞ'.toLowerCase() === 'Ṿ', which is presumed to be a bug
-  // fixed in v12 (couldn't find any details).
-  //
-  // So treat this one as a special case
-  // (remove this when node v10 is no longer supported).
-  //
-  if ('ẞ'.toLowerCase() === 'Ṿ') {
-    /* c8 ignore next 2 */
-    str = str.replace(/ẞ/g, 'ß')
-  }
 
   // .toLowerCase().toUpperCase() should get rid of all differences
   // between letter variants.


### PR DESCRIPTION
## Summary

Removes a Node.js 10 workaround in `normalizeReference()` that checked whether `'ẞ'.toLowerCase() === 'Ṿ'` — a bug fixed in Node.js 12 over 5 years ago.

## Changes

- `lib/common/utils.mjs`: Removed lines 231–240 (Node.js 10 workaround block)

## Why

Node.js 10 reached End-of-Life in April 2021. `markdown-it` is tested on Node.js 24. The workaround is dead code and adds unnecessary complexity.

Closes #1153