### PR TITLE
fix: use ASCII-only whitespace in normalizeReference (CommonMark spec §6.6)

### DIFF
--- a/lib/common/utils.mjs
+++ b/lib/common/utils.mjs
@@ -224,9 +224,12 @@ function isMdAsciiPunct (ch) {
 // Hepler to unify [reference labels].
 //
 function normalizeReference (str) {
-  // Trim and collapse whitespace
+  // CommonMark spec 6.6: strip leading/trailing spaces, tabs, and line endings;
+  // collapse consecutive internal spaces, tabs, and line endings to a single space.
+  // Non-ASCII whitespace (e.g. U+00A0 NBSP) is not in that set and must be
+  // preserved as a regular character.
   //
-  str = str.trim().replace(/\s+/g, ' ')
+  str = asciiTrim(str).replace(/[ \t\n\r]+/g, ' ')
 
   // In node v10 'ẞ'.toLowerCase() === 'Ṿ', which is presumed to be a bug
   // fixed in v12 (couldn't find any details).

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -834,3 +834,15 @@ b
 <p>c</p>
 </blockquote>
 .
+
+normalizeReference: non-ASCII whitespace (U+00A0) must be treated as regular character, not whitespace (CommonMark spec 6.6: only spaces/tabs/line-endings collapsed)
+.
+[foo bar]: /url1
+[foo bar]: /url2
+
+[foo bar]
+[foo bar]
+.
+<p><a href="/url1">foo bar</a>
+<a href="/url2">foo bar</a></p>
+.


### PR DESCRIPTION
## Bug

CommonMark spec §6.6 says link label normalization must strip leading/trailing **"spaces, tabs, and line endings"** and collapse consecutive internal **"spaces, tabs, and line endings"** to a single space.

The previous code used `.trim()` and `/\s+/g`, which both match Unicode whitespace characters (e.g. U+00A0 NO-BREAK SPACE) that the spec does not include in that set. This caused distinct reference labels that differ only by a non-ASCII whitespace character to be incorrectly normalised to the same key.

**Reproducer:**

```markdown
[foo\u00A0bar]: /url1
[foo bar]: /url2

[foo\u00A0bar]
[foo bar]
```

Before this fix both labels resolved to `/url1`. They should resolve to `/url1` and `/url2` respectively, because U+00A0 is not a "space, tab, or line ending" per the spec.

## Fix

In `lib/common/utils.mjs` → `normalizeReference`:

- Replace `.trim()` with `asciiTrim()` (already defined in the same file and used since #1074).
- Replace `/\s+/g` with `/[ \t\n\r]+/g` to restrict collapsing to the ASCII whitespace characters the spec names.

## Verification

```
npm run test:markdown-it   # 290 pass, 0 fail
npm run test:cmspec         # 0 fail
npm run lint                # 0 warnings
```

> AI-assisted: this PR was drafted with AI help.