### PR TITLE
fix: render code spans and escaped chars in img alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Code spans, escaped characters and entities inside img alt are now rendered
+  as their plain text content instead of being dropped, #1142.
+
 ## [14.2.0] - 2026-05-24
 ### Added
 - `isPunctCharCode` to utilities.

--- a/lib/renderer.mjs
+++ b/lib/renderer.mjs
@@ -270,6 +270,8 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
   for (let i = 0, len = tokens.length; i < len; i++) {
     switch (tokens[i].type) {
       case 'text':
+      case 'code_inline':
+      case 'text_special':
         result += tokens[i].content
         break
       case 'image':

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -741,6 +741,27 @@ Html in image description
 <p><img src="image.png" alt="text &lt;textarea&gt; text"></p>
 .
 
+Code span in image description (content kept as plain text, same as cmark)
+.
+![foo *bar* `baz` bla](image.png)
+.
+<p><img src="image.png" alt="foo bar baz bla"></p>
+.
+
+Escaped characters in image description (kept as their literal value)
+.
+![5 \< 6 \& 7 \> 4 \* 9](image.png)
+.
+<p><img src="image.png" alt="5 &lt; 6 &amp; 7 &gt; 4 * 9"></p>
+.
+
+Entities in image description (decoded, then escaped for the attribute)
+.
+![AT&amp;T &copy; 2024](image.png)
+.
+<p><img src="image.png" alt="AT&amp;T © 2024"></p>
+.
+
 
 https://github.com/commonmark/commonmark.js/pull/279
 


### PR DESCRIPTION
Closes #1142.

### Problem

`Renderer.renderInlineAsText` (used to build an image's `alt` attribute) only handles `text`, `image`, `html_inline`/`html_block` and `softbreak`/`hardbreak` tokens. It silently drops two other token types that carry literal content:

- **`code_inline`** — inline code spans (this is the case from #1142)
- **`text_special`** — backslash escapes and HTML entities (introduced in v13 by the `escape`/`entity` inline rules)

As a result, content disappears from `alt`:

```js
md.render('![foo *bar* `baz` bla](x.png)')
// <p><img src="x.png" alt="foo bar  bla"></p>   ← "baz" gone, double space

md.render('![5 \\< 6 \\& 7 \\> 4](x.png)')
// <p><img src="x.png" alt="5  6  7  4"></p>      ← escaped chars gone

md.render('![AT&amp;T](x.png)')
// <p><img src="x.png" alt="ATT"></p>            ← entity gone
```

The `text_special` drop is a regression from v13, since those tokens did not exist before then.

### Fix

Handle `code_inline` and `text_special` the same way as `text` (append their `content`). The attribute value is still HTML-escaped by the renderer, so `<`, `&`, `>` come out correctly:

```html
<p><img src="x.png" alt="foo bar baz bla"></p>
<p><img src="x.png" alt="5 &lt; 6 &amp; 7 &gt; 4"></p>
<p><img src="x.png" alt="AT&amp;T"></p>
```

### Why this is the correct behavior

The CommonMark spec (§6.4 Images) recommends that *"only the plain string content of the image description be used ... without formatting."* A backslash-escaped `\*` **is** the literal character `*`, and `&amp;` decodes to `&`, so their plain string content is `*` and `&` respectively — not "nothing".

The reference implementation (`commonmark.js`) confirms this: when rendering `alt` it suppresses tags (e.g. `<code>`) via `disableTags` but still emits the inner text through the escaping `out()`. So code-span content and decoded escapes/entities are kept as plain text — exactly the output this PR produces.

This also matches the existing handling of `html_inline`/`hardbreak`, which were added to `renderInlineAsText` in d9885ba (#979) with the same "match the reference implementations" rationale.

### Tests

Added three fixtures to `test/fixtures/markdown-it/commonmark_extras.txt` (code span, escaped characters, entities in image description). They fail on `master` and pass with the fix. Full suite (lint + CommonMark conformance + markdown-it + build) is green.
