### PR TITLE
fix: keep backslash-space hard line break (CommonMark 6.7)

### DIFF
--- a/lib/rules_inline/escape.mjs
+++ b/lib/rules_inline/escape.mjs
@@ -38,6 +38,20 @@ export default function escape (state, silent) {
     return true
   }
 
+  // '\' before a space is a literal backslash. Don't consume the space, so a
+  // trailing two-space hard line break is still detected by the newline rule.
+  if (ch1 === 0x20) {
+    if (!silent) {
+      const token = state.push('text_special', '', 0)
+      token.content = '\\'
+      token.markup = '\\'
+      token.info = 'escape'
+    }
+
+    state.pos = pos
+    return true
+  }
+
   let escapedStr = state.src[pos]
 
   if (ch1 >= 0xD800 && ch1 <= 0xDBFF && pos + 1 < max) {

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -834,3 +834,13 @@ b
 <p>c</p>
 </blockquote>
 .
+
+Backslash before a space (CommonMark 0.31.2 6.1) keeps the backslash literal and
+does not consume the space, so two trailing spaces still form a hard line break (6.7)
+.
+a\  
+b
+.
+<p>a\<br>
+b</p>
+.


### PR DESCRIPTION
## Problem

A backslash followed by two trailing spaces before a newline should emit a hard line break, but markdown-it downgrades it to a soft break and leaves a stray space.

Repro:

```js
md.render('a\\  \nb')
```

Expected (matches the CommonMark 0.31.2 reference renderer):

```html
<p>a\<br>
b</p>
```

Actual on current `master`:

```html
<p>a\
b</p>
```

The backslash is kept literal (correct), but the hard line break is gone and a space leaks into the output.

## Why

Per CommonMark 0.31.2:

- Section 6.1: a backslash before a space is a literal backslash; the space is not consumed.
- Section 6.7: a line ending preceded by two or more spaces is a hard line break.

In `lib/rules_inline/escape.mjs`, when `\` is not followed by a newline, the rule builds a `text_special` token whose content is the backslash plus the following character, and advances past that character. When the following character is a space, that space gets absorbed into the escape token. `lib/rules_inline/newline.mjs` then inspects `state.pending` for trailing spaces and finds only one, so it takes the soft-break branch.

## Fix

Special-case a space after the backslash: push a `text_special` token holding just the literal backslash and leave `state.pos` pointing at the space, so the space stays in the text stream and two-space hard-break detection still fires.

Controls verified unchanged: `a  \nb` (hard break), `a\\\nb` (backslash before newline, hard break), `x\ y` (mid-line literal backslash + space), `a\ \nb` (single trailing space stays a soft break).

## Tests

Added a fixture to `test/fixtures/markdown-it/commonmark_extras.txt` asserting `a\  \nb` renders the hard line break. It fails on `master` (actual `<p>a\ \nb</p>`) and passes with this change. The full suite is green, including all 652 CommonMark spec examples.
