### PR TITLE
fix: handle non-BMP punctuation and symbols in smart quotes

### DIFF
--- a/lib/rules_core/smartquotes.mjs
+++ b/lib/rules_core/smartquotes.mjs
@@ -7,6 +7,23 @@ const QUOTE_TEST_RE = /['"]/
 const QUOTE_RE = /['"]/g
 const APOSTROPHE = '\u2019' /* ’ */
 
+// Get the code point ending right before `pos`, taking surrogate pairs into
+// account. Mirrors the helper used by `scanDelims` (see #1072) so that the
+// flanking check here treats non-BMP punctuation/symbols the same way.
+function getLastCharCode (str, pos) {
+  /* eslint no-bitwise:0 */
+  // treat beginning of the line as a whitespace
+  if (pos <= 0) { return 0x20 }
+  const charCode = str.charCodeAt(pos - 1)
+  // not a low-surrogate code unit (is a BMP code point)
+  if ((charCode & 0xFC00) !== 0xDC00) { return charCode }
+
+  // undefined if out of range (e.g. an isolated low surrogate at index 0),
+  // and `undefined > 0xffff` is false, so we fall back to the code unit
+  const codePoint = str.codePointAt(pos - 2)
+  return codePoint > 0xffff ? codePoint : charCode
+}
+
 function addReplacement (replacements, tokenIdx, pos, ch) {
   if (!replacements[tokenIdx]) {
     replacements[tokenIdx] = []
@@ -72,13 +89,13 @@ function process_inlines (tokens, state) {
       let lastChar = 0x20
 
       if (t.index - 1 >= 0) {
-        lastChar = text.charCodeAt(t.index - 1)
+        lastChar = getLastCharCode(text, t.index)
       } else {
         for (j = i - 1; j >= 0; j--) {
           if (tokens[j].type === 'softbreak' || tokens[j].type === 'hardbreak') break // lastChar defaults to 0x20
           if (!tokens[j].content) continue // should skip all tokens except 'text', 'html_inline' or 'code_inline'
 
-          lastChar = tokens[j].content.charCodeAt(tokens[j].content.length - 1)
+          lastChar = getLastCharCode(tokens[j].content, tokens[j].content.length)
           break
         }
       }
@@ -89,13 +106,13 @@ function process_inlines (tokens, state) {
       let nextChar = 0x20
 
       if (pos < max) {
-        nextChar = text.charCodeAt(pos)
+        nextChar = text.codePointAt(pos)
       } else {
         for (j = i + 1; j < tokens.length; j++) {
           if (tokens[j].type === 'softbreak' || tokens[j].type === 'hardbreak') break // nextChar defaults to 0x20
           if (!tokens[j].content) continue // should skip all tokens except 'text', 'html_inline' or 'code_inline'
 
-          nextChar = tokens[j].content.charCodeAt(0)
+          nextChar = tokens[j].content.codePointAt(0)
           break
         }
       }

--- a/test/fixtures/markdown-it/smartquotes.txt
+++ b/test/fixtures/markdown-it/smartquotes.txt
@@ -190,3 +190,16 @@ Should not replace entities:
 <p>&quot;foo&quot;</p>
 <p>&quot;foo&quot;</p>
 .
+
+Recognize non-BMP punctuation and symbols when placing quotes (cf. #1072):
+.
+𝜵'x
+
+𝜵"x"
+
+"x"𝜵
+.
+<p>𝜵'x</p>
+<p>𝜵“x”</p>
+<p>“x”𝜵</p>
+.


### PR DESCRIPTION
#1072 made `scanDelims` surrogate-pair aware so emphasis flanking handles astral punctuation/symbols. The smartquotes rule runs the same left/right flanking check to decide whether a `'`/`"` is opening, closing, or an apostrophe, but it still reads the neighbouring characters with `charCodeAt`. For a character outside the BMP that yields a lone surrogate, which counts as neither punctuation nor whitespace, so a quote next to it gets placed differently than next to the equivalent BMP character.

With `typographer: true`:

```
input    before     after
𝜵'x      𝜵’x        𝜵'x
𝜵"x"     𝜵"x"       𝜵“x”
"x"𝜵     "x"𝜵       “x”𝜵
```

`𝜵` is U+1D735 (a math symbol). The BMP nabla `∇` already produced the "after" output, so this only makes the astral case consistent with its BMP equivalent.

The change follows #1072: a small `getLastCharCode` helper for the two backward reads and `codePointAt` for the two forward reads. That helper is a copy of the one in `scanDelims`; happy to lift it into a shared util instead if you'd rather not duplicate it.

Added cases to `test/fixtures/markdown-it/smartquotes.txt`; the fixture fails on `master` without the lib change.
