### PR TITLE
fix: keep a literal backslash before a space in a link destination

### DIFF
--- a/lib/helpers/parse_link_destination.mjs
+++ b/lib/helpers/parse_link_destination.mjs
@@ -49,7 +49,7 @@ export default function parseLinkDestination (str, start, max) {
     if (code < 0x20 || code === 0x7F) { break }
 
     if (code === 0x5C /* \ */ && pos + 1 < max) {
-      if (str.charCodeAt(pos + 1) === 0x20) { break }
+      if (str.charCodeAt(pos + 1) === 0x20) { pos++; continue }
       pos += 2
       continue
     }

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -844,3 +844,18 @@ b
 <p>a\<br>
 b</p>
 .
+
+Backslash before a space inside a link destination (CommonMark 0.31.2 6.3) is a
+literal backslash, and the space ends the destination
+.
+[a](/url\ )
+.
+<p><a href="/url%5C">a</a></p>
+.
+
+Backslash before a space in a link destination, followed by a title
+.
+[a](/url\ "title")
+.
+<p><a href="/url%5C" title="title">a</a></p>
+.


### PR DESCRIPTION
## Description

A literal backslash immediately before a space in an unenclosed link destination is dropped, so the whole link fails to parse.

```
[a](/url\ )
```

- markdown-it (master): `<p>[a](/url\ )</p>` (not a link)
- CommonMark 0.31.2 reference: `<p><a href="/url%5C">a</a></p>` (a valid link)

Per CommonMark 6.1/6.3, a space is not ASCII punctuation, so `\ ` is not an escape: the backslash is a literal destination character and the space terminates the destination. In `lib/helpers/parse_link_destination.mjs`, on a backslash followed by a space the scanner did `break`, ending the destination before the backslash and leaving `\ )` unconsumed, so the link failed to match. This affects the `commonmark` and `default` presets, inline links, and reference definitions.

## Fix

Advance past the backslash and keep scanning, so it stays a literal destination character and the space terminates the destination as normal.

```diff
-      if (str.charCodeAt(pos + 1) === 0x20) { break }
+      if (str.charCodeAt(pos + 1) === 0x20) { pos++; continue }
```

The existing case where content follows the space (`[a](a\ b)`, which must not parse) is preserved: the space still ends the destination and the trailing `b` blocks the link, matching the reference.

## Test

Added two cases to `test/fixtures/markdown-it/commonmark_extras.txt` (backslash-space destination, and the same followed by a title). They fail before the change and pass after; the CommonMark spec suite and the markdown-it suite stay green with no fixture churn.
