### PR TITLE
fix: recognize lowercase declarations as HTML blocks (CommonMark 4.6)

### DIFF
--- a/lib/rules_block/html_block.mjs
+++ b/lib/rules_block/html_block.mjs
@@ -10,7 +10,7 @@ const HTML_SEQUENCES = [
   [/^<(script|pre|style|textarea)(?=(\s|>|$))/i, /<\/(script|pre|style|textarea)>/i, true],
   [/^<!--/, /-->/, true],
   [/^<\?/, /\?>/, true],
-  [/^<![A-Z]/, />/, true],
+  [/^<![A-Za-z]/, />/, true],
   [/^<!\[CDATA\[/, /\]\]>/, true],
   [new RegExp('^</?(' + block_names.join('|') + ')(?=(\\s|/?>|$))', 'i'), /^$/, true],
   [new RegExp(HTML_OPEN_CLOSE_TAG_RE.source + '\\s*$'), /^$/, false]

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -859,3 +859,12 @@ Backslash before a space in a link destination, followed by a title
 .
 <p><a href="/url%5C" title="title">a</a></p>
 .
+
+HTML block type 4 (declaration) starts with `<!` plus any ASCII letter, not only uppercase (CommonMark 4.6, start condition 4). A lowercase declaration must interrupt a paragraph.
+.
+foo
+<!bar baz>
+.
+<p>foo</p>
+<!bar baz>
+.


### PR DESCRIPTION
CommonMark start condition 4 for HTML blocks (spec 4.6) says a block begins with
`<!` followed by an ASCII letter. ASCII letter means both cases, [A-Za-z].

The block rule in lib/rules_block/html_block.mjs matches only [A-Z], so a line
like

    foo
    <!bar baz>

is not recognized as an HTML block. Instead the declaration is pulled into the
preceding paragraph as inline HTML:

    <p>foo
    <!bar baz></p>

The spec-correct output, and the output of the reference commonmark.js renderer,
is:

    <p>foo</p>
    <!bar baz>

because an HTML block of type 4 interrupts a paragraph.

The inline HTML rule already uses the correct range: lib/common/html_re.mjs has
`const declaration = '<![A-Za-z][^>]*>'`. This change makes the block rule match
the same range, so uppercase and lowercase declarations behave the same.

Change: `/^<![A-Z]/` becomes `/^<![A-Za-z]/`.

Added a fixture in test/fixtures/markdown-it/commonmark_extras.txt covering a
lowercase declaration interrupting a paragraph.

All 652 CommonMark spec examples and the full markdown-it suite pass.
