### PR TITLE
Validate input type in parseInline

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -540,6 +540,10 @@ MarkdownIt.prototype.render = function (src, env) {
  * tokens in `children` property. Also updates `env` object.
  **/
 MarkdownIt.prototype.parseInline = function (src, env) {
+  if (typeof src !== 'string') {
+    throw new Error('Input data should be a String')
+  }
+
   const state = new this.core.State(src, this, env)
 
   state.inlineMode = true

--- a/test/markdown-it/misc.test.mjs
+++ b/test/markdown-it/misc.test.mjs
@@ -156,11 +156,14 @@ describe('API', function () {
 
   it('input type check', function () {
     const md = markdownit()
+    const expectedError = {
+      name: 'Error',
+      message: 'Input data should be a String'
+    }
 
-    assert.throws(
-      function () { md.render(null) },
-      /Input data should be a String/
-    )
+    assert.throws(() => md.render(null), expectedError)
+    assert.throws(() => md.renderInline(null), expectedError)
+    assert.throws(() => md.parseInline(null, {}), expectedError)
   })
 })
 


### PR DESCRIPTION
## Summary

This PR adds input type validation to `parseInline()` so it matches the existing behavior of `parse()`.

Currently, `parse()` validates that `src` is a string before creating parser state and throws:

```js
Error('Input data should be a String')
```

However, `parseInline()` does not perform the same validation. As a result, `renderInline(null)` and direct `parseInline(null, {})` calls can expose lower-level `TypeError`s from the core normalization path instead of markdown-it’s existing input validation error.

## Change

This adds the same input type guard used by `parse()` at the start of `parseInline()`.

This keeps validation at the parser API boundary and avoids changing lower-level core state or normalization behavior.

## Behavior

Before this change, invalid inline input could fail later in normalization with an implementation-dependent error such as:

```txt
TypeError: Cannot read properties of null (reading 'replace')
```

After this change, inline parsing fails consistently with the existing `parse()` behavior:

```txt
Error: Input data should be a String
```

Valid string input and markdown rendering behavior are unchanged.

## Tests

Updated the existing `input type check` test to cover:

```js
md.render(null)
md.renderInline(null)
md.parseInline(null, {})
```

The added inline assertions fail before the fix and pass after the fix.