### PR TITLE
fix: keep code span content in image alt text

### DIFF
--- a/lib/renderer.mjs
+++ b/lib/renderer.mjs
@@ -270,6 +270,7 @@ Renderer.prototype.renderInlineAsText = function (tokens, options, env) {
   for (let i = 0, len = tokens.length; i < len; i++) {
     switch (tokens[i].type) {
       case 'text':
+      case 'code_inline':
         result += tokens[i].content
         break
       case 'image':

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -19,6 +19,13 @@ Strip markdown in ALT tags
 <p><img src="#" alt="strip markdown in alt"></p>
 .
 
+Issue #1142: keep code span content in ALT tags (as CommonMark reference does)
+.
+![foo `code` bar](#)
+.
+<p><img src="#" alt="foo code bar"></p>
+.
+
 Issue #55:
 .
 ![test]


### PR DESCRIPTION
## Problem

`renderInlineAsText` skipped `code_inline` tokens, so backtick-wrapped text inside an image description was dropped entirely, leaving a stray double space in the alt attribute. For example, `![foo ``code`` bar](#)` produced `alt="foo  bar"` (double space) instead of including the code span content.

## Fix

Render `code_inline` content in `renderInlineAsText` (alongside `text`), so the literal code content (without backticks) is preserved in alt text. This aligns with the CommonMark reference implementation, which includes the literal code content in alt text.

## Testing

Added a fixture case to `test/fixtures/markdown-it/commonmark_extras.txt` covering an image whose description contains a code span; it now renders the code content in the `alt` attribute (`alt="foo code bar"`).

Closes #1142
