### PR TITLE
demo: restrict permalink-loaded options to a presentation allow-list

### DIFF
--- a/support/demo_template/index.mjs
+++ b/support/demo_template/index.mjs
@@ -380,6 +380,14 @@ function loadPermalink () {
 
   const opts = isObject(cfg.defaults) ? cfg.defaults : {}
 
+  // Presentation-only options that a permalink is allowed to set. These
+  // control display/formatting and cannot cause script execution. Notably
+  // `html` is excluded: it enables raw-HTML pass-through, whose output is
+  // written to innerHTML, so a permalink must never be able to set it.
+  const permalinkAllowed = [
+    '_view', '_strict', 'langPrefix', 'breaks', 'linkify', 'typographer', 'xhtmlOut'
+  ]
+
   // copy config to defaults, but only if key exists
   // and value has the same type
   Object.entries(opts).forEach(function ([key, val]) {
@@ -390,6 +398,8 @@ function loadPermalink () {
       defaults._view = val ? 'src' : 'html'
       return
     }
+
+    if (permalinkAllowed.indexOf(key) === -1) { return }
 
     if ((typeof defaults[key] === 'boolean' && typeof val === 'boolean') ||
         (typeof defaults[key] === 'string' && typeof val === 'string')) {


### PR DESCRIPTION
The demo page's `loadPermalink()` parses options out of the URL fragment and copies them into the live `defaults` object for any key that already exists with a matching primitive type. This allowed a crafted permalink to set arbitrary defaults, including `html`.

Enabling `html` turns on raw-HTML pass-through, and the rendered result is assigned to `.result-html`'s innerHTML, so a link of the form `#md3=...{defaults:{html:true},source:"<img src=x onerror=...>"}` would execute attacker-controlled script in the browser of whoever opened it.

This restricts the keys a permalink may set to a fixed presentation-only allow-list (`_view`, `_strict`, `langPrefix`, `breaks`, `linkify`, `typographer`, `xhtmlOut`). These control display/formatting only and cannot cause script execution. `html` is deliberately excluded. The existing same-type check and the legacy `_src` handling are preserved.