### PR TITLE
Remove obsolete Node.js 10 workaround in normalizeReference()

### DIFF
--- a/lib/common/utils.mjs
+++ b/lib/common/utils.mjs
@@ -228,17 +228,6 @@ function normalizeReference (str) {
   //
   str = str.trim().replace(/\s+/g, ' ')
 
-  // In node v10 'ẞ'.toLowerCase() === 'Ṿ', which is presumed to be a bug
-  // fixed in v12 (couldn't find any details).
-  //
-  // So treat this one as a special case
-  // (remove this when node v10 is no longer supported).
-  //
-  if ('ẞ'.toLowerCase() === 'Ṿ') {
-    /* c8 ignore next 2 */
-    str = str.replace(/ẞ/g, 'ß')
-  }
-
   // .toLowerCase().toUpperCase() should get rid of all differences
   // between letter variants.
   //


### PR DESCRIPTION
## Summary
- Drops the Node.js 10-era `ẞ`/`Ṿ` special case in `normalizeReference()`.
- That runtime check is dead on current Node and browsers, so the branch never runs.

Fixes #1153

## Test plan
- [x] `npm test`