### PR TITLE
Optimize newline regex in normalize rule

### DIFF
--- a/src/rules_core/normalize.ts
+++ b/src/rules_core/normalize.ts
@@ -3,14 +3,14 @@
 import type StateCore from './state_core.ts'
 
 // https://spec.commonmark.org/0.29/#line-ending
-const NEWLINES_RE = /\r\n?|\n/g
+const UNNORMALIZED_NEWLINE_RE = /\r\n?/g
 const NULL_RE = /\0/g
 
 export default function normalize (state: StateCore): void {
   let str
 
   // Normalize newlines
-  str = state.src.replace(NEWLINES_RE, '\n')
+  str = state.src.replace(UNNORMALIZED_NEWLINE_RE, '\n')
 
   // Replace NULL characters
   str = str.replace(NULL_RE, '\uFFFD')


### PR DESCRIPTION
This PR simplifies the newline regex in the normalize rule by ignoring singular newlines (`\n`).

Previously, the regex matched `\r\n`, `\r`, and `\n`, which were then replaced by `\n`. Since replacing `\n` with `\n` is a no-op, we can remove the alternation from the regex and improve its performance.

Since the regex now only matches unnormalized newlines instead of all commonmark newlines, I've renamed it to prevent confusion.

## Benchmarks
I extended `profile.mjs` to check the average time to parse `fixtures/commonmark/spec.txt` across 5,000 iterations:
4.371ms before -> 3.679ms after (15.8% improvement).

Across the benchmark suite, no regressions, with up to 39.82% performance improvement:
| Sample File | Mode | Ops/Sec (Before) | Ops/Sec (After) | Change |
| :--- | :--- | :--- | :--- | :--- |
| README.md | current | 2,555 | 2,698 | +5.60% |
| README.md | commonmark | 5,450 | 6,185 | +13.49% |
| block-bq-flat.md | current | 104,297 | 110,694 | +6.13% |
| block-bq-flat.md | commonmark | 209,234 | 234,258 | +11.96% |
| block-bq-nested.md | current | 85,596 | 91,038 | +6.36% |
| block-bq-nested.md | commonmark | 106,098 | 113,330 | +6.82% |
| block-code.md | current | 833,308 | 1,133,913 | +36.07% |
| block-code.md | commonmark | 846,556 | 1,153,854 | +36.30% |
| block-fences.md | current | 665,462 | 896,066 | +34.65% |
| block-fences.md | commonmark | 674,002 | 942,382 | +39.82% |
| block-heading.md | current | 149,587 | 161,076 | +7.68% |
| block-heading.md | commonmark | 183,014 | 200,830 | +9.73% |
| block-hr.md | current | 287,780 | 331,418 | +15.16% |
| block-hr.md | commonmark | 317,981 | 377,289 | +18.65% |
| block-html.md | current | 174,849 | 206,928 | +18.35% |
| block-html.md | commonmark | 184,683 | 219,777 | +19.00% |
| block-lheading.md | current | 144,718 | 153,065 | +5.77% |
| block-lheading.md | commonmark | 219,197 | 236,937 | +8.09% |
| block-list-flat.md | current | 35,797 | 39,483 | +10.30% |
| block-list-flat.md | commonmark | 40,895 | 45,772 | +11.93% |
| block-list-nested.md | current | 41,325 | 44,833 | +8.49% |
| block-list-nested.md | commonmark | 47,699 | 52,507 | +10.08% |
| block-ref-flat.md | current | 15,469 | 15,555 | +0.56% |
| block-ref-flat.md | commonmark | 17,589 | 17,783 | +1.10% |
| block-ref-list.md | current | 21,891 | 22,932 | +4.76% |
| block-ref-list.md | commonmark | 25,523 | 27,352 | +7.17% |
| block-ref-nested.md | current | 27,385 | 28,267 | +3.22% |
| block-ref-nested.md | commonmark | 31,410 | 32,330 | +2.93% |
| block-tables.md | current | 41,330 | 42,428 | +2.66% |
| block-tables.md | commonmark | 72,441 | 76,633 | +5.79% |
| inline-autolink.md | current | 20,018 | 20,358 | +1.70% |
| inline-autolink.md | commonmark | 60,230 | 62,770 | +4.22% |
| inline-backticks.md | current | 282,065 | 311,438 | +10.41% |
| inline-backticks.md | commonmark | 331,847 | 370,200 | +11.56% |
| inline-em-flat.md | current | 80,822 | 83,792 | +3.67% |
| inline-em-flat.md | commonmark | 92,495 | 96,649 | +4.49% |
| inline-em-nested.md | current | 91,813 | 95,346 | +3.85% |
| inline-em-nested.md | commonmark | 105,539 | 110,521 | +4.72% |
| inline-em-worst.md | current | 110,806 | 115,858 | +4.56% |
| inline-em-worst.md | commonmark | 131,878 | 140,248 | +6.35% |
| inline-entity.md | current | 85,474 | 90,177 | +5.50% |
| inline-entity.md | commonmark | 103,163 | 108,710 | +5.38% |
| inline-escape.md | current | 77,213 | 81,605 | +5.69% |
| inline-escape.md | commonmark | 103,775 | 112,941 | +8.83% |
| inline-html.md | current | 31,588 | 32,719 | +3.58% |
| inline-html.md | commonmark | 42,664 | 45,012 | +5.50% |
| inline-links-flat.md | current | 21,370 | 21,621 | +1.17% |
| inline-links-flat.md | commonmark | 38,056 | 39,401 | +3.53% |
| inline-links-nested.md | current | 7,891 | 7,925 | +0.43% |
| inline-links-nested.md | commonmark | 13,044 | 13,124 | +0.61% |
| inline-newlines.md | current | 123,099 | 137,016 | +11.31% |
| inline-newlines.md | commonmark | 143,796 | 164,176 | +14.17% |
| lorem1.txt | current | 21,450 | 21,907 | +2.13% |
| lorem1.txt | commonmark | 38,401 | 39,784 | +3.60% |
| rawtabs.md | current | 160,931 | 177,715 | +10.43% |
| rawtabs.md | commonmark | 209,066 | 237,824 | +13.75% |

All benchmarks run on an i7-13700