### PR TITLE
fix: honor escaped characters in linkify autolinks

### DIFF
--- a/src/rules_inline/linkify.ts
+++ b/src/rules_inline/linkify.ts
@@ -1,9 +1,27 @@
 // Process links like https://example.org/
 
+import { isMdAsciiPunct, unescapeMd } from '../common/utils.ts'
 import type StateInline from './state_inline.ts'
 
 // RFC3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 const SCHEME_RE = /(?:^|[^a-z0-9.+-])([a-z][a-z0-9.+-]*)$/i
+
+// `\` + ASCII punct is one character after CommonMark unescape.
+function srcLengthForUnescaped (src: string, start: number, unescapedLength: number): number {
+  let i = start
+  let consumed = 0
+
+  while (consumed < unescapedLength && i < src.length) {
+    if (src.charCodeAt(i) === 0x5C/* \ */ && i + 1 < src.length && isMdAsciiPunct(src.charCodeAt(i + 1))) {
+      i += 2
+    } else {
+      i++
+    }
+    consumed++
+  }
+
+  return i - start
+}
 
 export default function linkify (state: StateInline, silent: boolean): boolean {
   if (!state.md.options.linkify) return false
@@ -22,7 +40,8 @@ export default function linkify (state: StateInline, silent: boolean): boolean {
 
   const proto = match[1]
 
-  const link = state.md.linkify.matchAtStart(state.src.slice(pos - proto.length))
+  // matchAtStart on raw source stops at `\`; unescape so git\-scm.com stays one URL
+  const link = state.md.linkify.matchAtStart(unescapeMd(state.src.slice(pos - proto.length, max)))
   if (!link) return false
 
   let url = link.url
@@ -60,6 +79,6 @@ export default function linkify (state: StateInline, silent: boolean): boolean {
     token_c.info = 'auto'
   }
 
-  state.pos += url.length - proto.length
+  state.pos += srcLengthForUnescaped(state.src, pos, url.length - proto.length)
   return true
 }

--- a/test/fixtures/markdown-it/linkify.txt
+++ b/test/fixtures/markdown-it/linkify.txt
@@ -151,3 +151,11 @@ https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkeli
 .
 <p><a href="https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf">https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf</a></p>
 .
+
+
+linkify escaped characters inside url
+.
+See https://git\-scm.com/docs/gitignore\#\_pattern\_format.
+.
+<p>See <a href="https://git-scm.com/docs/gitignore#_pattern_format">https://git-scm.com/docs/gitignore#_pattern_format</a>.</p>
+.


### PR DESCRIPTION
## Description

With `linkify: true`, a CommonMark escape inside a `scheme://` URL stops the autolink at the backslash:

```
See https://git\-scm.com/docs/gitignore\#\_pattern\_format.
```

becomes `<a href="https://git">https://git</a>-scm.com/...` instead of one link to `https://git-scm.com/docs/gitignore#_pattern_format`.

The inline linkify rule matches `://` on raw source so emphasis inside a URL is not applied (v13). `\` is not a URL host character, so linkify-it ends the match there even though `\-` / `\#` / `\_` are just escaped punctuation.

## Fix

Unescape Markdown ASCII punctuation before `matchAtStart`, then advance `state.pos` by the corresponding source length (each `\` + punct counts as one character).

This does not change the v13 cases that are supposed to stay unlinked:

- `google\.com` (fuzzy / core linkify + `text_special`)
- `\https://...`, `https\://...`, `https:\//...` (escape still breaks the raw `://` trigger)

Wrapping with `<...>` remains the way to force an autolink when needed.

Fixes #1058