### PR TITLE
fix: don't let an unclosed link label suppress a later code span

### DIFF
--- a/src/helpers/parse_link_label.ts
+++ b/src/helpers/parse_link_label.ts
@@ -7,6 +7,19 @@ export default function parseLinkLabel (state: StateInline, start: number, disab
   const max = state.posMax
   const oldPos = state.pos
 
+  // The backtick cache (`state.backticks` / `state.backticksScanned`) memoizes a
+  // single left-to-right scan of the current line. `skipToken()` below runs the
+  // inline rules in silent mode purely as a lookahead, so it must not leak into
+  // that cache: a code span consumed during the lookahead hides its closing
+  // backtick run from the cache, and reaching the end of the line flips the
+  // `backticksScanned` latch. Either would make the real parse miss a valid code
+  // span once the label turns out not to be a link. Give the lookahead its own
+  // cache and restore the caller's afterwards, exactly as we do for `state.pos`.
+  const oldBackticks = state.backticks
+  const oldBackticksScanned = state.backticksScanned
+  state.backticks = {}
+  state.backticksScanned = false
+
   state.pos = start + 1
   level = 1
 
@@ -28,6 +41,8 @@ export default function parseLinkLabel (state: StateInline, start: number, disab
         level++
       } else if (disableNested) {
         state.pos = oldPos
+        state.backticks = oldBackticks
+        state.backticksScanned = oldBackticksScanned
         return -1
       }
     }
@@ -41,6 +56,8 @@ export default function parseLinkLabel (state: StateInline, start: number, disab
 
   // restore old state
   state.pos = oldPos
+  state.backticks = oldBackticks
+  state.backticksScanned = oldBackticksScanned
 
   return labelEnd
 }

--- a/test/fixtures/markdown-it/commonmark_extras.txt
+++ b/test/fixtures/markdown-it/commonmark_extras.txt
@@ -876,3 +876,19 @@ foo
 <p>foo</p>
 <!bar baz>
 .
+
+An unclosed link label (`[`) must not suppress a later code span. Code spans bind
+more tightly than links (CommonMark 0.31.2 6.1), so the lookahead that searches for
+the label's closing `]` must not disturb code-span scanning of the rest of the line.
+.
+[foo `bar` baz`
+.
+<p>[foo <code>bar</code> baz`</p>
+.
+
+The same holds for an unclosed image label (`![`), which uses the same lookahead.
+.
+![alt `code` x`
+.
+<p>![alt <code>code</code> x`</p>
+.


### PR DESCRIPTION
Fixes #1201.

## What

Fixes a CommonMark conformance bug: an unclosed link or image label (`[` / `![`) earlier on a line silently causes a later, valid inline code span to be rendered as literal text.

```js
const md = require('markdown-it')('commonmark');
md.render('[foo `bar` baz`');
// markdown-it 15.0.0:   <p>[foo `bar` baz`</p>          ← code span lost
// CommonMark reference: <p>[foo <code>bar</code> baz`</p>
```

Also affects image labels and the default/zero presets:

```js
md.render('![alt `code` x`');
// markdown-it:  <p>![alt `code` x`</p>
// reference:    <p>![alt <code>code</code> x`</p>
```

Minimal trigger `` [`a`b` ``. Removing the leading bracket (`` a`a`b` ``, `` *`a`b` ``) makes markdown-it agree with the reference again, which pins the cause to the label scan rather than the backtick rule per se.

Code spans bind more tightly than links (CommonMark 0.31.2 §6.1 and the precedence rule), so this is a spec divergence on valid input. It slips past the existing `spec.txt` suite only because no spec example combines an unclosed label with a trailing unmatched backtick run.

- markdown-it demo (CommonMark strict): <https://markdown-it.github.io/#md64=eyJzb3VyY2UiOiJbZm9vIGBiYXJgIGJhemAiLCJkZWZhdWx0cyI6eyJodG1sIjpmYWxzZSwieGh0bWxPdXQiOmZhbHNlLCJicmVha3MiOmZhbHNlLCJsYW5nUHJlZml4IjoibGFuZ3VhZ2UtIiwibGlua2lmeSI6dHJ1ZSwidHlwb2dyYXBoZXIiOnRydWUsIl9oaWdobGlnaHQiOnRydWUsIl9zdHJpY3QiOnRydWUsIl92aWV3IjoiaHRtbCJ9fQ==>
- CommonMark dingus: <https://spec.commonmark.org/dingus/?text=%5Bfoo%20%60bar%60%20baz%60>

## Why it happens

`parseLinkLabel` searches for a label's closing `]` by running the inline rules in silent mode via `skipToken`. The backtick rule's scan memo — `state.backticks` and the `state.backticksScanned` latch (added in 8cd6fc3 to fix the #736 quadratic backtick blowup) — is shared through that lookahead. `backticksScanned` is only meaningful for a single monotonic left-to-right scan, but the lookahead:

1. consumes a code span, which hides its closing backtick run from the cache, and
2. scans to end-of-line and flips `backticksScanned = true` with an incomplete cache.

When the label turns out not to be a link, the real parse reaches the earlier backtick opener and hits the false-literal guard `state.backticksScanned && (state.backticks[openerLength] || 0) <= start`, emitting the backticks literally even though a real closer exists.

`parseLinkLabel` is a pure lookahead — it already saves and restores `state.pos` — but it does not isolate this scan memo.

## Fix

Give the lookahead its own throwaway backtick cache and restore the caller's afterward, exactly as `state.pos` is handled. The restore is an O(1) reference swap, so the #736 quadratic guard is preserved.

## Tests / evidence

- Added two cases to `test/fixtures/markdown-it/commonmark_extras.txt` (link and image variants); reverting only the source fix makes exactly these two fail (`tests 297, pass 295, fail 2` → with the fix `pass 297, fail 0`).
- Full `npm test` green (lint, build, strict type-check, cmspec 100%, markdown-it 297 pass, build test); pathological suite 30/30 within the per-case timeout.
- Differential fuzz against `commonmark@0.31.2` (the reference that powers the dingus): every input whose output differs between the current build and this branch is a correction toward the reference — no regressions, and the only bracket+backtick behavioral change is this fix.
- Adversarial `[`-plus-backticks inputs (single bracket + thousands of increasing backtick runs; tens of thousands of `` [`a`b` `` groups; long `` [` `` interleaves) stay linear and finish in tens of milliseconds, equal-or-faster than the current build — the O(1) memo swap does not reintroduce #736's quadratic cost.

## What I could not verify

- I validated correctness against `commonmark@0.31.2` (the reference implementation behind the CommonMark dingus) rather than clicking through the live dingus UI; permalinks to both the markdown-it demo (CommonMark strict) and the dingus are above.
- Fuzzing also surfaced unrelated, pre-existing divergences in a different subsystem (reference-definition "empty output" edge cases in `rules_block/reference.ts`, and code-span interior all-whitespace handling). Those are byte-identical between the current build and this branch, so they are out of scope for this fix.

Verified against markdown-it@15.0.0 on the current `master`.
