### PR TITLE
fix: preserve IPv6 brackets in normalizeLink

### DIFF
--- a/src/markdownit.ts
+++ b/src/markdownit.ts
@@ -62,6 +62,17 @@ const GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/
 
 const RECODE_HOSTNAME_FOR = ['http:', 'https:', 'mailto:']
 
+function encodeLink (parsed: mdurl.Url): string {
+  return mdurl.format({
+    ...parsed,
+    auth: parsed.auth && mdurl.encode(parsed.auth),
+    hostname: parsed.hostname && mdurl.encode(parsed.hostname),
+    pathname: parsed.pathname && mdurl.encode(parsed.pathname),
+    search: parsed.search && mdurl.encode(parsed.search),
+    hash: parsed.hash && mdurl.encode(parsed.hash)
+  })
+}
+
 /**
  * Parses Markdown into tokens and renders them to HTML.
  *
@@ -162,7 +173,7 @@ class MarkdownIt {
       }
     }
 
-    return mdurl.encode(mdurl.format(parsed))
+    return encodeLink(parsed)
   }
 
   /**

--- a/test/fixtures/markdown-it/normalize.txt
+++ b/test/fixtures/markdown-it/normalize.txt
@@ -60,6 +60,26 @@ Two slashes should start a domain:
 <p><a href="//xn--n3h.net/"></a></p>
 .
 
+IPv6 address literals should preserve brackets while encoding other components:
+
+.
+[foo](http://[2001:db8::1]:1896/a[b]?x=[y])
+.
+<p><a href="http://[2001:db8::1]:1896/a%5Bb%5D?x=%5By%5D">foo</a></p>
+.
+
+.
+[foo](//[::ffff:192.0.2.1]/)
+.
+<p><a href="//[::ffff:192.0.2.1]/">foo</a></p>
+.
+
+.
+[foo](http://user:password@[2001:db8:0:0:0:0:0:1]:1926/)
+.
+<p><a href="http://user:password@[2001:db8:0:0:0:0:0:1]:1926/">foo</a></p>
+.
+
 Don't encode domains in unknown schemas:
 
 .


### PR DESCRIPTION
mdurl.encode() treats '[' and ']' as unsafe and percent-encodes them, so IPv6 address literals such as http://[2001:db8::1]/ were emitted as http://%5B2001:db8::1%5D/. Encode URL components individually and let mdurl.format() add the IPv6 brackets back as URL syntax delimiters.

---

Reference to #1205.